### PR TITLE
reuse common PDMS strings

### DIFF
--- a/RvmSharp/RvmAttributeParser.cs
+++ b/RvmSharp/RvmAttributeParser.cs
@@ -86,7 +86,9 @@
                         else
                         {
                             var (key, value) = SplitKeyValue(trimmedLine, headerInfo.NameEnd.AsSpan());
-                            currentPdmsNode!.MetadataDict[key] = StripQuotes(value);
+                            var keyInterned = string.Intern(key);
+                            var valueInterned = string.Intern(StripQuotes(value));
+                            currentPdmsNode!.MetadataDict[keyInterned] = valueInterned;
                         }
                     }
                 }


### PR DESCRIPTION
reuse string objects using string.Intern() for PDMS parsing of attributes

HULDRA: increases RVM load time from 2.4s to 4.8s, and decreases string memory usage from 196 MB to 57 MB
TROLL A: increases RVM load time from 16s to 21s, no data on memory usage

## Before
![image](https://user-images.githubusercontent.com/4621581/140531772-55d0f60b-86aa-44cd-952a-8e12e40f00cf.png)

## After
![image](https://user-images.githubusercontent.com/4621581/140530673-d79b3dc2-6dda-4449-9696-736b27e5aa98.png)
