### PR TITLE
speedup geometry connect

### DIFF
--- a/RvmSharp/Operations/RvmConnect.cs
+++ b/RvmSharp/Operations/RvmConnect.cs
@@ -67,7 +67,7 @@
 
                 for (int i = j + 1; i < anchors.Length && anchors[i].Position.X <= anchors[j].Position.X + epsilon; i++)
                 {
-                    bool canMatch = anchors[i].Matched == false && anchors[i].Geo != anchors[j].Geo;
+                    bool canMatch = anchors[i].Matched == false && !ReferenceEquals(anchors[i].Geo, anchors[j].Geo);
                     bool close = Vector3.DistanceSquared(anchors[j].Position, anchors[i].Position) <= epsilonSquared;
 
                     const float alignedThreshold = -0.98f;


### PR DESCRIPTION
### before

Matched 175038 of 569341 anchors 00:00:11.2255408.

### after

Matched 175584 of 568973 anchors 00:00:01.1099652.