### PR TITLE
Bug/mariner builds failing

### DIFF
--- a/CadRevealComposer/Operations/SectorSplitter.cs
+++ b/CadRevealComposer/Operations/SectorSplitter.cs
@@ -281,7 +281,7 @@ public static class SectorSplitter
                 }
             );
 
-
+        // Always add atleast one node if there is still budget left, to avoid nothing ever being added if the largest node exceeds the maximum budget
         var budgetLeft = budget;
         foreach (var node in nodesInPrioritizedOrder)
         {


### PR DESCRIPTION
Making sure that something is added when checking the budget. Probably hinders a possible large object, which is larger than the budget, to continuously be pushed down the hierarchy. 