### PR TITLE
Ignore ILTUBOF

### DIFF
--- a/CadRevealComposer/Operations/HierarchyComposerConverter.cs
+++ b/CadRevealComposer/Operations/HierarchyComposerConverter.cs
@@ -41,7 +41,16 @@ public static class HierarchyComposerConverter
             return null;
 
         var maybeRefNoString = rvmNode.Attributes.GetValueOrNull("RefNo");
-        var maybeRefNo = maybeRefNoString != null ? RefNo.Parse(maybeRefNoString) : null;
+
+        RefNo? maybeRefNo = null;
+        if (!string.IsNullOrWhiteSpace(maybeRefNoString)
+            &&
+            // TEMP: 2022-08-25 Ignore ILTUBOF RefNos instead of actually handling them, as the database does not yet support representing this.
+            !maybeRefNoString.Trim().StartsWith("ILTUBOF", StringComparison.OrdinalIgnoreCase)
+           )
+        {
+            maybeRefNo = RefNo.Parse(maybeRefNoString);
+        }
 
         var boundingBox = revealNode.BoundingBoxAxisAligned;
         bool hasMesh = revealNode.RvmGeometries.Any();


### PR DESCRIPTION
ILTUBOF are special RefNos that indicate that this "RefNo" is actually just the next thing in the hierarchy following another RefNo. This makes it possible to represent cylinders. We must handle this in a near future, so a task will be created to follow this up.

I created a follow up task in [AB#77900](https://dev.azure.com/EquinorASA/5f193d29-b7e1-4e23-aba0-7eac7e847ab5/_workitems/edit/77900)