### PR TITLE
Exclude cylinders with invalid rotation value

### DIFF
--- a/CadRevealRvmProvider/Converters/RvmCylinderConverter.cs
+++ b/CadRevealRvmProvider/Converters/RvmCylinderConverter.cs
@@ -18,9 +18,9 @@ public static class RvmCylinderConverter
             throw new Exception("Failed to decompose matrix to transform. Input Matrix: " + rvmCylinder.Matrix);
         }
 
-        if(!(float.IsFinite(rotation.X) && float.IsFinite(rotation.Y) & float.IsFinite(rotation.Z) && float.IsFinite(rotation.W)))
+        if(!(float.IsFinite(rotation.X) && float.IsFinite(rotation.Y) && float.IsFinite(rotation.Z) && float.IsFinite(rotation.W)))
         {
-            Console.WriteLine("Cylinder was removed due to invalid rotation values");
+            Console.WriteLine($"Cylinder was removed due to invalid rotation values: {rotation}");
             yield break;
         }
 


### PR DESCRIPTION
Fixing bug with cylinders that for some reason gets an invalid rotation value.  Mitigating by logging and ignoring such cylinders.  Known to happen once for JSB.

Fixes [AB#98736](https://dev.azure.com/EquinorASA/5f193d29-b7e1-4e23-aba0-7eac7e847ab5/_workitems/edit/98736)