### PR TITLE
Splitting Experiments

### DIFF
--- a/CadRevealComposer/Operations/SectorSplitting/SectorSplitterOctree.cs
+++ b/CadRevealComposer/Operations/SectorSplitting/SectorSplitterOctree.cs
@@ -10,7 +10,8 @@ using Utils;
 
 public class SectorSplitterOctree : ISectorSplitter
 {
-    private const long SectorEstimatedByteSizeBudget = 2_500_000; // bytes, Arbitrary value
+    private const long SectorEstimatedByteSizeBudget = 2_000_000; // bytes, Arbitrary value
+    private const long SectorEstimatedPrimitiveBudget = 5_000; // count, Arbitrary value
     private const float DoNotChopSectorsSmallerThanMetersInDiameter = 17.4f; // Arbitrary value
     private const float MinDiagonalSizeAtDepth_1 = 7; // arbitrary value for min size at depth 1
     private const float MinDiagonalSizeAtDepth_2 = 4; // arbitrary value for min size at depth 2
@@ -265,21 +266,21 @@ public class SectorSplitterOctree : ISectorSplitter
             _ => nodes.ToArray(),
         };
 
-        var nodesInPrioritizedOrder = selectedNodes.OrderByDescending(
-            x => x.Diagonal * (1 - (0.01 * x.EstimatedTriangleCount))
-        );
+        var nodesInPrioritizedOrder = selectedNodes.OrderByDescending(x => x.Diagonal);
 
         var budgetLeft = budget;
         var nodeArray = nodesInPrioritizedOrder.ToArray();
+        var primitiveBudget = SectorEstimatedPrimitiveBudget;
         for (int i = 0; i < nodeArray.Length; i++)
         {
-            if (budgetLeft < 0 && nodeArray.Length - i > 10)
+            if (budgetLeft < 0 || primitiveBudget <= 0 && nodeArray.Length - i > 10)
             {
                 yield break;
             }
 
             var node = nodeArray[i];
             budgetLeft -= node.EstimatedByteSize;
+            primitiveBudget -= node.Geometries.Count(x => x is not (InstancedMesh or TriangleMesh));
             yield return node;
         }
     }

--- a/CadRevealComposer/Operations/SectorSplitting/SplittingUtils.cs
+++ b/CadRevealComposer/Operations/SectorSplitting/SplittingUtils.cs
@@ -154,17 +154,16 @@ public static class SplittingUtils
     public static Node[] ConvertPrimitivesToNodes(APrimitive[] primitives)
     {
         return primitives
-            .GroupBy(p => p.TreeIndex)
             .Select(g =>
             {
-                var geometries = g.ToArray();
+                var geometries = new[] { g };
                 var boundingBox = geometries.CalculateBoundingBox();
                 if (boundingBox == null)
                 {
                     throw new Exception("Unexpected error, the boundingbox should not have been null.");
                 }
                 return new Node(
-                    g.Key,
+                    g.TreeIndex,
                     geometries,
                     geometries.Sum(DrawCallEstimator.EstimateByteSize),
                     EstimatedTriangleCount: DrawCallEstimator.Estimate(geometries).EstimatedTriangleCount,


### PR DESCRIPTION
1. Reduce sector size. Cognite seems to use around 1 MB as a size
2. I believe primitives are too "Cheap" right now, and this may cause too many primitives in a sector. This limits the max amount of primitives to a reasonable amount in each sector.
3. I'm not sure if we NEEED to contain all geometries in the same part. Not sure if the effect here is measurable but I think its worth a shot. I have not seen any visual difference in the actual model.