### PR TITLE
Feature: Small geometry in own sector

### DIFF
--- a/CadRevealComposer/Operations/SectorSplitting/SectorSplitterOctree.cs
+++ b/CadRevealComposer/Operations/SectorSplitting/SectorSplitterOctree.cs
@@ -210,10 +210,9 @@ public class SectorSplitterOctree : ISectorSplitter
     }
 
     /*
-     * This method is intended to avoid the problem that we allways fill leaf sectors
-     * to the brim with content. This means that we can have a sector with both large and
-     * tiny parts. If this is the case we sometimes want to avoid loading all the tiny
-     * parts until we are closer to the sector.
+     * This method is intended to avoid the problem that we always fill leaf sectors to the brim with content.
+     * This means that we can have a sector with both large and tiny parts. If this is the case we sometimes want
+     * to avoid loading all the tiny parts until we are closer to the sector.
      */
     private IEnumerable<InternalSector> HandleLastNodes(
         Node[] nodes,


### PR DESCRIPTION
At the last splitting level, check if there are many small nodes and split the small ones to they're own sector. 

Maybe split when it has 1000 nodes that are smaller than 0.1 meter? 
Not sure how to test it properly.

Some stats from testing: 

Huldra (started with 161 sectors): 

Split smaller than 0.5: 196
Split smaller than 0.2: 224
Split smaller than 0.1: 226

0.1 with minimum 100 small nodes 217
0.1 with minimum 200: 215
0.1 with minimum 500: 204
0.1 with minimum 1000: 192  
0.1 with minimum 2000: 168
0.1 with minimum 5000: 162
0.1 with minimum 10000: 161


TrollA (started with 1499): 

Split smaller than 0.5: 2315
Split smaller than 0.2: 2314
Split smaller than 0.1: 2315
Split smaller than 0.05: 2311
Split smaller than 0.005: 2026

0.1 with minimum 1000: 1718
