### PR TITLE
Implement LOD system for V9 without forking

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,5 @@ While any contributions are appreciated please make an issue to discuss the appr
 This project is based on [rvmparser](https://github.com/cdyk/rvmparser) by @cdyk
 
 This repository contains sample data from the Equinor ASA - Huldra Dataset <https://data.equinor.com/dataset/Huldra>. A copy of the license can be found [here](./TestSamples/Huldra/Equinor_open_data_sharing_license_-_Huldra.pdf).
+
+//noPRWithoutChange


### PR DESCRIPTION
**Goal**

To be able to make a LOD system we would like to switch between sectors containing detailed and rough model parts. Ideally we would like to achieve this by only editing the Echo3DWeb code, and leave the Reveal code untouched. 

**Method**
 
By utilizing the sector weighting and the fact that we discard the sectors that are not interesting, we can chooses which of the sectors we want based on the weighting criteria. With the detailed sector named "sector_1" and the rough sector named "shadow_sector_1" (the names are arbitrary) we can simply give the shadow sector a weight of 0 when the detailed model should be shown, and the detailed sector a weight of 0 when the rough model should be shown. 

This can be achieved in frontend by just doing (prototype):
```
if (zone === CutoffZone.Near) {
        if (sector.sectorFileName?.includes("shadow")){
            return 0
        }
        return SectorZonePriority.zonePriorityTop + percentOfScreenFilledByLargestNode;
    }


    if (!sector.sectorFileName?.includes("shadow")){        
        return 0;
    }
    return SectorZonePriority.zonePriorityLow + percentOfScreenFilledByLargestNode;
```

**Evidence**

![pink](https://github.com/equinor/rvmsharp/assets/14194541/da670ce1-0570-4117-9d7b-cb97fb57bd4b)

**Conclusion**

This works fine, and it seems that we have everything we need to implement a decent LOD system without forking Reveal. 

NOTE: 
Sometimes there is a frame between unloading a detailed/shadow sector and loading a shadow/detailed sector. This has probably always been there, but is more visible now when switching with a rough model. It looks like the the model is "blinking". 

**Next steps:**

- This solution doubles the amount of sectors, so it is worth investigating if every sector needs a shadow sector. 
- Optimize the weighting for user experience
  - This is most likely only possible when we have an actual rough model available.  