### PR TITLE
WIP: Group outlier nodes by distance and run splitting on each group

### DIFF
--- a/CadRevealComposer/Operations/SectorSplitting/SectorSplitterOctree.cs
+++ b/CadRevealComposer/Operations/SectorSplitting/SectorSplitterOctree.cs
@@ -123,6 +123,13 @@ public class SectorSplitterOctree : ISectorSplitter
     private IEnumerable<Node[]> GroupOutliersRecursive(Node[] outlierNodes)
     {
         var groups = GroupOutliers(outlierNodes, outlierNodes[0].BoundingBox.Center);
+
+        if (groups.Count == 1)
+        {
+            yield return groups[0];
+            yield break;
+        }
+
         foreach (var group in groups)
         {
             if (nodesHasDistanceJump(group, OutlierGroupingDistance))


### PR DESCRIPTION
To avoid large outlier sectors, that might in worst case span over the main platform, the outliers are grouped based on size. Sector splitting is run on each group separately.

The result should be more sectors, but a lot smaller.

In the example from TrollA below there is an outlier up in the sky, and coincidentally a couple at he edge of the main platform sector. 

Depth 1 before:
<img src="https://github.com/equinor/rvmsharp/assets/14194541/f698d34c-0315-477d-87f3-b1d407f8a780" width="300px" />


Depth 1 after:
<img src="https://github.com/equinor/rvmsharp/assets/14194541/77164c2e-95e7-4939-a81b-0af930c7ad28" width = "300px" />