### PR TITLE
Add reading of opacity in case of insulation or obstruction chunk

### DIFF
--- a/RvmSharp/RvmParser.cs
+++ b/RvmSharp/RvmParser.cs
@@ -305,12 +305,12 @@ public static class RvmParser
                         group.AddChild(primitive);
                     }
                     break;
-                // types OBST (obstacle) and INSU (insulation) chunks were previously throwing an exception
-                // causing the building process to terminate
+                // types OBST (obstacle) and INSU (insulation) chunks were previously also throwing
+                // a NotImplementedException causing the building process to terminate
                 // now the corresponding stream is consumed, but they are skipped (not added to the scene)
                 //
-                // in order to add them to the scene, the primitive type needs to be extended as follows
-                // -- add a field for storing its type (primitive, obstacle, insulation)
+                // in order to add them to the scene, the primitive type needs to be extended as follows:
+                // -- add a field for storing the type of the chunk (primitive, obstacle, insulation)
                 // -- add a field for storing opacity if this should be supported by rendering
                 case "OBST":
                     ReadPrimitive(stream, true);


### PR DESCRIPTION
This is a super short PR.

Before: RvmParser was throwing a not implemented exception in case of encountering an insulation (INSU) or obstruction (OBST) chunk.

Now: Same routine is used as for reading primitives, but opacity is read out in addition. The object IS NOT added to the scene!

A log is produced that INSU/OBST has been encountered and skipped.