### PR TITLE
Adding SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ If you discover a security vulnerability in this project, please follow the step
   Create a GitHub issue for the vulnerability. Avoid putting sensitive information in the issue.
 
 - **Alternative B:**
-  Send an email to the projects maintainer at [security@example.com](mailto:security@example.com) describing the issue.
+  Contact at least two of the project's maintainers through internal Equinor slack or email, and describe the issue.
 
 ### For "critical" and time sensitive issues
 


### PR DESCRIPTION
TR2375 requires security policies for all repos. I have added a SECURITY.md file from the official Equinor template for internal repositories found [here](https://github.com/equinor/it-professional-network/blob/master/doc/SECURITY-template.md).