### PR TITLE
Refactor reused code in CapVisibilityHelpers

### DIFF
--- a/CadRevealRvmProvider/Converters/CapVisibilityHelpers/ComparerHelper.cs
+++ b/CadRevealRvmProvider/Converters/CapVisibilityHelpers/ComparerHelper.cs
@@ -1,0 +1,25 @@
+﻿namespace CadRevealRvmProvider.Converters.CapVisibilityHelpers;
+
+public static class ComparerHelper
+{
+    public static bool CheckOverlap(bool isCurrentPrimitive,
+        float radius1, float radius2, float radius3, float tolerance)
+    {
+        if (isCurrentPrimitive)
+        {
+            if (radius2 + tolerance >= radius1)
+            {
+                return false;
+            }
+        }
+        else
+        {
+            if (radius1 + tolerance >= radius3)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/CadRevealRvmProvider/Converters/CapVisibilityHelpers/CylinderCylinderComparer.cs
+++ b/CadRevealRvmProvider/Converters/CapVisibilityHelpers/CylinderCylinderComparer.cs
@@ -16,21 +16,12 @@ public static class CylinderCylinderComparer
         var cylinderRadius1 = rvmCylinder1.Radius * cylinderScale1.X;
         var cylinderRadius2 = rvmCylinder2.Radius * cylinderScale2.X;
 
-        if (cylinderData1.IsCurrentPrimitive)
-        {
-            if (cylinderRadius2 + CapVisibility.CapOverlapTolerance >= cylinderRadius1)
-            {
-                return false;
-            }
-        }
-        else
-        {
-            if (cylinderRadius1 + CapVisibility.CapOverlapTolerance >= cylinderRadius2)
-            {
-                return false;
-            }
-        }
-
-        return true;
+        return ComparerHelper.CheckOverlap(
+            cylinderData1.IsCurrentPrimitive,
+            cylinderRadius1,
+            cylinderRadius2,
+            cylinderRadius2,
+            CapVisibility.CapOverlapTolerance
+        );
     }
 }

--- a/CadRevealRvmProvider/Converters/CapVisibilityHelpers/CylinderEllipticalDishComparer.cs
+++ b/CadRevealRvmProvider/Converters/CapVisibilityHelpers/CylinderEllipticalDishComparer.cs
@@ -16,21 +16,12 @@ public static class CylinderEllipticalDishComparer
         var cylinderRadius = rvmCylinder.Radius * cylinderScale.X;
         var ellipticalDishRadius = rvmEllipticalDish.BaseRadius * ellipticalDishScale.X;
 
-        if (cylinderCapData.IsCurrentPrimitive)
-        {
-            if (ellipticalDishRadius + CapVisibility.CapOverlapTolerance >= cylinderRadius)
-            {
-                return false;
-            }
-        }
-        else
-        {
-            if (cylinderRadius + CapVisibility.CapOverlapTolerance >= ellipticalDishRadius)
-            {
-                return false;
-            }
-        }
-
-        return true;
+        return ComparerHelper.CheckOverlap(
+            cylinderCapData.IsCurrentPrimitive,
+            cylinderRadius,
+            ellipticalDishRadius,
+            ellipticalDishRadius,
+            CapVisibility.CapOverlapTolerance
+        );
     }
 }

--- a/CadRevealRvmProvider/Converters/CapVisibilityHelpers/CylinderSnoutComparer.cs
+++ b/CadRevealRvmProvider/Converters/CapVisibilityHelpers/CylinderSnoutComparer.cs
@@ -26,21 +26,12 @@ public static class CylinderSnoutComparer
         var semiMinorRadius = snoutEllipse.semiMinorAxis * snoutScale.X;
         var semiMajorRadius = snoutEllipse.semiMajorAxis * snoutScale.X;
 
-        if (cylinderCapData.IsCurrentPrimitive)
-        {
-            if (semiMinorRadius + CapVisibility.CapOverlapTolerance >= cylinderRadius)
-            {
-                return false;
-            }
-        }
-        else
-        {
-            if (cylinderRadius + CapVisibility.CapOverlapTolerance >= semiMajorRadius)
-            {
-                return false;
-            }
-        }
-
-        return true;
+        return ComparerHelper.CheckOverlap(
+            cylinderCapData.IsCurrentPrimitive,
+            cylinderRadius,
+            (float)semiMinorRadius,
+            (float)semiMajorRadius,
+            CapVisibility.CapOverlapTolerance
+        );
     }
 }

--- a/CadRevealRvmProvider/Converters/CapVisibilityHelpers/CylinderSphericalDishComparer.cs
+++ b/CadRevealRvmProvider/Converters/CapVisibilityHelpers/CylinderSphericalDishComparer.cs
@@ -16,21 +16,12 @@ public static class CylinderSphericalDishComparer
         var cylinderRadius = rvmCylinder.Radius * cylinderScale.X;
         var rvmSphericalDishRadius = rvmSphericalDish.BaseRadius * sphericalDishScale.X;
 
-        if (cylinderCapData.IsCurrentPrimitive)
-        {
-            if (rvmSphericalDishRadius + CapVisibility.CapOverlapTolerance >= cylinderRadius)
-            {
-                return false;
-            }
-        }
-        else
-        {
-            if (cylinderRadius + CapVisibility.CapOverlapTolerance >= rvmSphericalDishRadius)
-            {
-                return false;
-            }
-        }
-
-        return true;
+        return ComparerHelper.CheckOverlap(
+            cylinderCapData.IsCurrentPrimitive,
+            cylinderRadius,
+            rvmSphericalDishRadius,
+            rvmSphericalDishRadius,
+            CapVisibility.CapOverlapTolerance
+        );
     }
 }

--- a/CadRevealRvmProvider/Converters/CapVisibilityHelpers/EllipticalDishSnoutComparer.cs
+++ b/CadRevealRvmProvider/Converters/CapVisibilityHelpers/EllipticalDishSnoutComparer.cs
@@ -26,21 +26,12 @@ public static class EllipticalDishSnoutComparer
         var semiMinorRadius = snoutEllipse.semiMinorAxis * snoutScale.X;
         var semiMajorRadius = snoutEllipse.semiMajorAxis * snoutScale.X;
 
-        if (ellipticalDishCapData.IsCurrentPrimitive)
-        {
-            if (semiMinorRadius + CapVisibility.CapOverlapTolerance >= ellipticalDishRadius)
-            {
-                return false;
-            }
-        }
-        else
-        {
-            if (ellipticalDishRadius + CapVisibility.CapOverlapTolerance >= semiMajorRadius)
-            {
-                return false;
-            }
-        }
-
-        return true;
+        return ComparerHelper.CheckOverlap(
+            ellipticalDishCapData.IsCurrentPrimitive,
+            ellipticalDishRadius,
+            (float)semiMinorRadius,
+            (float)semiMajorRadius,
+            CapVisibility.CapOverlapTolerance
+        );
     }
 }

--- a/CadRevealRvmProvider/Converters/CapVisibilityHelpers/SnoutSnoutComparer.cs
+++ b/CadRevealRvmProvider/Converters/CapVisibilityHelpers/SnoutSnoutComparer.cs
@@ -61,16 +61,16 @@ public static class SnoutSnoutComparer
         double y0E1 = ellipseCurrent.ellipse2DPolar.y0;
         double theta = ellipseCurrent.ellipse2DPolar.theta;
 
-        var ptE1_xplaneCoord = new VectorD[4];
-        ptE1_xplaneCoord[0] = VectorD.Build.Dense(new double[] { aE1 - x0E1, -y0E1, 0.0f, 1.0 });
-        ptE1_xplaneCoord[1] = VectorD.Build.Dense(new double[] { -x0E1, bE1 - y0E1, 0.0f, 1.0 });
-        ptE1_xplaneCoord[2] = VectorD.Build.Dense(new double[] { -aE1 - x0E1, -y0E1, 0.0f, 1.0 });
-        ptE1_xplaneCoord[3] = VectorD.Build.Dense(new double[] { -x0E1, -bE1 - y0E1, 0.0f, 1.0 });
+        var ptE1XplaneCoord = new VectorD[4];
+        ptE1XplaneCoord[0] = VectorD.Build.Dense(new double[] { aE1 - x0E1, -y0E1, 0.0f, 1.0 });
+        ptE1XplaneCoord[1] = VectorD.Build.Dense(new double[] { -x0E1, bE1 - y0E1, 0.0f, 1.0 });
+        ptE1XplaneCoord[2] = VectorD.Build.Dense(new double[] { -aE1 - x0E1, -y0E1, 0.0f, 1.0 });
+        ptE1XplaneCoord[3] = VectorD.Build.Dense(new double[] { -x0E1, -bE1 - y0E1, 0.0f, 1.0 });
 
         var cosTheta = Math.Cos(theta);
         var sinTheta = Math.Sin(theta);
         var matRotationEl1 = DenseMatrix.OfArray(
-            new double[,]
+            new[,]
             {
                 { cosTheta, sinTheta, 0.0, 0.0 },
                 { sinTheta, cosTheta, 0.0, 0.0 },
@@ -79,17 +79,17 @@ public static class SnoutSnoutComparer
             }
         );
 
-        var mat_stack =
+        var matStack =
             ellipseOther.modelToPlaneCoord
             * worldToSnout2
             * snout1ToWorld
             * ellipseCurrent.planeToModelCoord
             * matRotationEl1;
 
-        var ptE1_transformedTo_xplaneCoordOfE2 = new VectorD[4];
+        var ptE1TransformedToXplaneCoordOfE2 = new VectorD[4];
         for (int i = 0; i < 4; i++)
         {
-            ptE1_transformedTo_xplaneCoordOfE2[i] = mat_stack.Multiply(ptE1_xplaneCoord[i]);
+            ptE1TransformedToXplaneCoordOfE2[i] = matStack.Multiply(ptE1XplaneCoord[i]);
         }
 
         // hide cap if all four points (extremities) of the ellipse (cap) are inside the other cap
@@ -99,8 +99,8 @@ public static class SnoutSnoutComparer
         const int y = 1;
         for (int i = 0; i < 4; i++)
         {
-            var px = ptE1_transformedTo_xplaneCoordOfE2[i][x];
-            var py = ptE1_transformedTo_xplaneCoordOfE2[i][y];
+            var px = ptE1TransformedToXplaneCoordOfE2[i][x];
+            var py = ptE1TransformedToXplaneCoordOfE2[i][y];
 
             var d = ConicSectionsHelper.CalcDistancePointEllise(ellipseOther.ellipse2DPolar, px, py);
             if (d > 0.1) // 0.1mm

--- a/CadRevealRvmProvider/Converters/CapVisibilityHelpers/TorusCylinderComparer.cs
+++ b/CadRevealRvmProvider/Converters/CapVisibilityHelpers/TorusCylinderComparer.cs
@@ -16,21 +16,12 @@ public static class TorusCylinderComparer
         var circularTorusRadius = rvmCircularTorus.Radius * circularTorusScale.X;
         var cylinderRadius = rvmCylinder.Radius * cylinderScale.X;
 
-        if (torusCapData.IsCurrentPrimitive)
-        {
-            if (cylinderRadius + CapVisibility.CapOverlapTolerance >= circularTorusRadius)
-            {
-                return false;
-            }
-        }
-        else
-        {
-            if (circularTorusRadius + CapVisibility.CapOverlapTolerance >= cylinderRadius)
-            {
-                return false;
-            }
-        }
-
-        return true;
+        return ComparerHelper.CheckOverlap(
+            torusCapData.IsCurrentPrimitive,
+            circularTorusRadius,
+            cylinderRadius,
+            cylinderRadius,
+            CapVisibility.CapOverlapTolerance
+        );
     }
 }

--- a/CadRevealRvmProvider/Converters/CapVisibilityHelpers/TorusSnoutComparer.cs
+++ b/CadRevealRvmProvider/Converters/CapVisibilityHelpers/TorusSnoutComparer.cs
@@ -26,21 +26,12 @@ public static class TorusSnoutComparer
         var semiMinorRadius = snoutEllipse.semiMinorAxis * snoutScale.X;
         var semiMajorRadius = snoutEllipse.semiMajorAxis * snoutScale.X;
 
-        if (torusCapData.IsCurrentPrimitive)
-        {
-            if (semiMinorRadius + CapVisibility.CapOverlapTolerance >= torusRadius)
-            {
-                return false;
-            }
-        }
-        else
-        {
-            if (torusRadius + CapVisibility.CapOverlapTolerance >= semiMajorRadius)
-            {
-                return false;
-            }
-        }
-
-        return true;
+        return ComparerHelper.CheckOverlap(
+            torusCapData.IsCurrentPrimitive,
+            torusRadius,
+            (float)semiMinorRadius,
+            (float)semiMajorRadius,
+            CapVisibility.CapOverlapTolerance
+        );
     }
 }

--- a/CadRevealRvmProvider/Converters/CapVisibilityHelpers/TorusTorusComparer.cs
+++ b/CadRevealRvmProvider/Converters/CapVisibilityHelpers/TorusTorusComparer.cs
@@ -16,21 +16,12 @@ public static class TorusTorusComparer
         var torusRadius1 = rvmCircularTorus1.Radius * torusScale1.X;
         var torusRadius2 = rvmCircularTorus2.Radius * torusScale2.X;
 
-        if (torusCapData1.IsCurrentPrimitive)
-        {
-            if (torusRadius2 + CapVisibility.CapOverlapTolerance >= torusRadius1)
-            {
-                return false;
-            }
-        }
-        else
-        {
-            if (torusRadius1 + CapVisibility.CapOverlapTolerance >= torusRadius2)
-            {
-                return false;
-            }
-        }
-
-        return true;
+        return ComparerHelper.CheckOverlap(
+            torusCapData1.IsCurrentPrimitive,
+            torusRadius1,
+            torusRadius2,
+            torusRadius2,
+            CapVisibility.CapOverlapTolerance
+        );
     }
 }


### PR DESCRIPTION
### Problem
For the comparer helpers of primitives in CapVisibilityHelpers, there is an overlap check of the caps. The final 15 or so lines of code that does this is reused nine times.

### Method
We suggest making a helper function which checks overlap, trying to reduce reused code. The current helper is already covered by tests.

### To review this PR:
Read the new changes, consider whether the refactoring is worth it and if so, come up with suggestions to improve it.