### PR TITLE
Remove unused using directives

### DIFF
--- a/CadRevealComposer.Tests/Operations/Tessellating/CircleTessellatorTests.cs
+++ b/CadRevealComposer.Tests/Operations/Tessellating/CircleTessellatorTests.cs
@@ -1,7 +1,7 @@
 ﻿namespace CadRevealComposer.Tests.Operations.Tessellating;
 
 using CadRevealComposer.Operations.Tessellating;
-using CadRevealComposer.Primitives;
+using Primitives;
 using System.Drawing;
 using System.Numerics;
 

--- a/CadRevealComposer.Tests/Operations/Tessellating/ConeTessellatorTests.cs
+++ b/CadRevealComposer.Tests/Operations/Tessellating/ConeTessellatorTests.cs
@@ -1,8 +1,7 @@
 ﻿namespace CadRevealComposer.Tests.Operations.Tessellating;
 
 using CadRevealComposer.Operations.Tessellating;
-using CadRevealComposer.Primitives;
-using System;
+using Primitives;
 using System.Drawing;
 using System.Numerics;
 

--- a/CadRevealComposer.Tests/Operations/Tessellating/EccentricConeTessellatorTests.cs
+++ b/CadRevealComposer.Tests/Operations/Tessellating/EccentricConeTessellatorTests.cs
@@ -1,7 +1,7 @@
 ﻿namespace CadRevealComposer.Tests.Operations.Tessellating;
 
 using CadRevealComposer.Operations.Tessellating;
-using CadRevealComposer.Primitives;
+using Primitives;
 using System.Drawing;
 using System.Numerics;
 

--- a/CadRevealComposer.Tests/Operations/Tessellating/GeneralRingTessellatorTests.cs
+++ b/CadRevealComposer.Tests/Operations/Tessellating/GeneralRingTessellatorTests.cs
@@ -2,7 +2,6 @@
 
 using CadRevealComposer.Operations.Tessellating;
 using Primitives;
-using System;
 using System.Drawing;
 using System.Numerics;
 

--- a/CadRevealComposer.Tests/Operations/Tessellating/TessellationUtilsTests.cs
+++ b/CadRevealComposer.Tests/Operations/Tessellating/TessellationUtilsTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace CadRevealComposer.Tests.Operations.Tessellating;
 
 using CadRevealComposer.Operations.Tessellating;
-using System;
 using System.Numerics;
 
 [TestFixture]

--- a/CadRevealComposer.Tests/Operations/Tessellating/TorusSegmentTessellatorTests.cs
+++ b/CadRevealComposer.Tests/Operations/Tessellating/TorusSegmentTessellatorTests.cs
@@ -1,8 +1,7 @@
 ﻿namespace CadRevealComposer.Tests.Operations.Tessellating;
 
 using CadRevealComposer.Operations.Tessellating;
-using CadRevealComposer.Primitives;
-using System;
+using Primitives;
 using System.Drawing;
 using System.Numerics;
 

--- a/CadRevealComposer/ModelMetadata.cs
+++ b/CadRevealComposer/ModelMetadata.cs
@@ -1,11 +1,6 @@
 ﻿namespace CadRevealComposer;
 
-using System;
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Text.Json;
 
 public class ModelMetadata

--- a/CadRevealComposer/Operations/Tessellating/CircleTessellator.cs
+++ b/CadRevealComposer/Operations/Tessellating/CircleTessellator.cs
@@ -1,13 +1,13 @@
 ﻿namespace CadRevealComposer.Operations.Tessellating;
 
-using CadRevealComposer.Primitives;
-using CadRevealComposer.Tessellation;
-using CadRevealComposer.Utils;
 using Commons.Utils;
+using Primitives;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using Tessellation;
+using Utils;
 
 public static class CircleTessellator
 {

--- a/CadRevealComposer/Operations/Tessellating/EccentricConeTessellator.cs
+++ b/CadRevealComposer/Operations/Tessellating/EccentricConeTessellator.cs
@@ -1,13 +1,12 @@
 ﻿namespace CadRevealComposer.Operations.Tessellating;
 
-using CadRevealComposer.Primitives;
-using CadRevealComposer.Tessellation;
 using Commons.Utils;
+using Primitives;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using System.Numerics;
+using Tessellation;
 using Utils;
 
 public static class EccentricConeTessellator

--- a/CadRevealComposer/Operations/Tessellating/GeneralRingTessellator.cs
+++ b/CadRevealComposer/Operations/Tessellating/GeneralRingTessellator.cs
@@ -1,14 +1,13 @@
 ﻿namespace CadRevealComposer.Operations.Tessellating;
 
-using CadRevealComposer.Primitives;
-using CadRevealComposer.Tessellation;
-using CadRevealComposer.Utils;
 using Commons.Utils;
+using Primitives;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using System.Numerics;
+using Tessellation;
+using Utils;
 
 public static class GeneralRingTessellator
 {

--- a/CadRevealComposer/Operations/Tessellating/TessellationUtils.cs
+++ b/CadRevealComposer/Operations/Tessellating/TessellationUtils.cs
@@ -1,13 +1,13 @@
 ﻿namespace CadRevealComposer.Operations.Tessellating;
 
-using CadRevealComposer.Primitives;
-using CadRevealComposer.Tessellation;
-using CadRevealComposer.Utils;
+using Primitives;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Numerics;
+using Tessellation;
+using Utils;
 
 public static class TessellationUtils
 {

--- a/CadRevealRvmProvider/Converters/ConverterExceptionHandling.cs
+++ b/CadRevealRvmProvider/Converters/ConverterExceptionHandling.cs
@@ -2,7 +2,6 @@
 
 using CadRevealComposer.Utils;
 using RvmSharp.Primitives;
-using System.Diagnostics;
 using System.Numerics;
 
 public static class ConverterExceptionHandling

--- a/CadRevealRvmProvider/Converters/RvmPrimitiveToAPrimitive.cs
+++ b/CadRevealRvmProvider/Converters/RvmPrimitiveToAPrimitive.cs
@@ -1,7 +1,6 @@
 ﻿namespace CadRevealRvmProvider.Converters;
 
 using CadRevealComposer.Primitives;
-using CadRevealComposer.Utils;
 using RvmSharp.Primitives;
 
 public static class RvmPrimitiveToAPrimitive

--- a/RvmSharp/RvmParser.cs
+++ b/RvmSharp/RvmParser.cs
@@ -1,8 +1,8 @@
 ﻿namespace RvmSharp;
 
 using Containers;
+using Operations;
 using Primitives;
-using RvmSharp.Operations;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/RvmSharp/Tessellation/TessellationHelpers.cs
+++ b/RvmSharp/Tessellation/TessellationHelpers.cs
@@ -1,6 +1,5 @@
 ﻿namespace RvmSharp.Tessellation;
 
-using System;
 using System.Numerics;
 
 public static class TessellationHelpers


### PR DESCRIPTION
In this PR we remove unused using directives to reduce noise in the code base.

This is a part of this too large https://github.com/equinor/rvmsharp/pull/201.