### PR TITLE
Revert "Add aabbs in rtree (sqlite)"

### DIFF
--- a/HierarchyComposer/Functions/DatabaseComposer.cs
+++ b/HierarchyComposer/Functions/DatabaseComposer.cs
@@ -154,12 +154,6 @@ public class DatabaseComposer
             {
                 using var transaction = connection.BeginTransaction();
                 using var cmd = new SQLiteCommand(connection);
-
-                // Manually creating a special R-Tree table to speed up queries on the AABB table, specifically finding AABBs based on a location. The sqlite rtree module auto-creates spatial indexes.
-                cmd.CommandText =
-                    "CREATE VIRTUAL TABLE AABBs USING rtree(Id, min_x, max_x, min_y, max_y, min_z, max_z)";
-                cmd.ExecuteNonQuery();
-
                 AABB.RawInsertBatch(cmd, aabbs.Values);
 
                 transaction.Commit();

--- a/HierarchyComposer/HierarchyContext.cs
+++ b/HierarchyComposer/HierarchyContext.cs
@@ -7,9 +7,8 @@ public class HierarchyContext : DbContext
 {
     public DbSet<Node> Nodes => Set<Node>();
     public DbSet<PDMSEntry> PdmsEntries => Set<PDMSEntry>();
+    public DbSet<AABB> Aabbs => Set<AABB>();
     public DbSet<NodePDMSEntry> NodeToPDMSEntry => Set<NodePDMSEntry>();
-
-    // NOTE: The AABB table is created in DatabaseComposer, because R-Tree isn't supported in the Enitity Framework
 
     // This connection string is only used during manual migration from command line, use HierarchyContext(DbContextOptions)
     // constructor runtime.
@@ -32,6 +31,7 @@ public class HierarchyContext : DbContext
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<PDMSEntry>().ToTable("PDMSEntries");
+        modelBuilder.Entity<AABB>().ToTable("AABBs");
         modelBuilder.Entity<NodePDMSEntry>().HasKey(e => new { e.NodeId, e.PDMSEntryId });
         modelBuilder
             .Entity<NodePDMSEntry>()


### PR DESCRIPTION
Reverts equinor/rvmsharp#216

This caused performance issues in prod that we need to diagnose and find a solution for. Seems like every request depends on more IO which does not work as expected on the VMs in Azure