### PR TITLE
Extend the scaffold optimizer framework to enable use of primitives

### DIFF
--- a/CadRevealFbxProvider.Tests/BatchUtils/ScaffoldOptimizerTests.cs
+++ b/CadRevealFbxProvider.Tests/BatchUtils/ScaffoldOptimizerTests.cs
@@ -155,6 +155,9 @@ public class ScaffoldOptimizerTests
     [Test]
     public void CheckScaffoldOptimizerActivation_GivenTestPartOptimizers_VerifyingTheReturnedNode()
     {
+        ulong currentInstanceId = 100;
+        var onRequestNewInstanceId = () => currentInstanceId++;
+
         // Set up the input
         CadRevealNode nodeA = CreateCadRevealNode("TestNode, Test A test").node;
         CadRevealNode nodeB = CreateCadRevealNode("TestNode, Test B test").node;
@@ -173,10 +176,10 @@ public class ScaffoldOptimizerTests
         optimizer.AddPartOptimizer(optimizerB);
 
         // Invoke the optimizer
-        optimizer.OptimizeNode(nodeA);
-        optimizer.OptimizeNode(nodeB);
-        optimizer.OptimizeNode(nodeC);
-        optimizer.OptimizeNode(nodeD);
+        optimizer.OptimizeNode(nodeA, onRequestNewInstanceId);
+        optimizer.OptimizeNode(nodeB, onRequestNewInstanceId);
+        optimizer.OptimizeNode(nodeC, onRequestNewInstanceId);
+        optimizer.OptimizeNode(nodeD, onRequestNewInstanceId);
 
         // Check the results
         CheckGeometries(nodeA.Geometries, optimizerA.GetVerticesTruth(), optimizerA.GetIndicesTruth(), boundingBoxes);

--- a/CadRevealFbxProvider.Tests/BatchUtils/ScaffoldPartOptimizers/ScaffoldPartOptimizerTest.cs
+++ b/CadRevealFbxProvider.Tests/BatchUtils/ScaffoldPartOptimizers/ScaffoldPartOptimizerTest.cs
@@ -1,13 +1,18 @@
 namespace CadRevealFbxProvider.Tests.BatchUtils.ScaffoldPartOptimizers;
 
 using System.Numerics;
+using CadRevealComposer.Primitives;
 using CadRevealComposer.Tessellation;
 using CadRevealFbxProvider.BatchUtils.ScaffoldPartOptimizers;
 
 public abstract class ScaffoldPartOptimizerTest : IScaffoldPartOptimizer
 {
     public abstract string Name { get; }
-    public abstract Mesh[] Optimize(Mesh mesh);
+    public abstract IScaffoldOptimizerResult[] Optimize(
+        APrimitive basePrimitive,
+        Mesh mesh,
+        Func<ulong, int, ulong> requestChildPartInstanceId
+    );
     public abstract string[] GetPartNameTriggerKeywords();
 
     public abstract List<Vector3> GetVerticesTruth();

--- a/CadRevealFbxProvider.Tests/BatchUtils/ScaffoldPartOptimizers/ScaffoldPartOptimizerTestPartA.cs
+++ b/CadRevealFbxProvider.Tests/BatchUtils/ScaffoldPartOptimizers/ScaffoldPartOptimizerTestPartA.cs
@@ -1,7 +1,9 @@
 namespace CadRevealFbxProvider.Tests.BatchUtils.ScaffoldPartOptimizers;
 
 using System.Numerics;
+using CadRevealComposer.Primitives;
 using CadRevealComposer.Tessellation;
+using CadRevealFbxProvider.BatchUtils.ScaffoldPartOptimizers;
 
 public class ScaffoldPartOptimizerTestPartA : ScaffoldPartOptimizerTest
 {
@@ -20,9 +22,21 @@ public class ScaffoldPartOptimizerTestPartA : ScaffoldPartOptimizerTest
         get { return "Part A test optimizer"; }
     }
 
-    public override Mesh[] Optimize(Mesh mesh)
+    public override IScaffoldOptimizerResult[] Optimize(
+        APrimitive basePrimitive,
+        Mesh mesh,
+        Func<ulong, int, ulong> requestChildPartInstanceId
+    )
     {
-        return [new Mesh(GetVerticesTruth().ToArray(), GetIndicesTruth().ToArray(), mesh.Error)];
+        return
+        [
+            new ScaffoldOptimizerResult(
+                basePrimitive,
+                new Mesh(GetVerticesTruth().ToArray(), GetIndicesTruth().ToArray(), mesh.Error),
+                0,
+                requestChildPartInstanceId
+            )
+        ];
     }
 
     public override string[] GetPartNameTriggerKeywords()

--- a/CadRevealFbxProvider.Tests/BatchUtils/ScaffoldPartOptimizers/ScaffoldPartOptimizerTestPartB.cs
+++ b/CadRevealFbxProvider.Tests/BatchUtils/ScaffoldPartOptimizers/ScaffoldPartOptimizerTestPartB.cs
@@ -1,7 +1,9 @@
 namespace CadRevealFbxProvider.Tests.BatchUtils.ScaffoldPartOptimizers;
 
 using System.Numerics;
+using CadRevealComposer.Primitives;
 using CadRevealComposer.Tessellation;
+using CadRevealFbxProvider.BatchUtils.ScaffoldPartOptimizers;
 
 public class ScaffoldPartOptimizerTestPartB : ScaffoldPartOptimizerTest
 {
@@ -20,9 +22,21 @@ public class ScaffoldPartOptimizerTestPartB : ScaffoldPartOptimizerTest
         get { return "Part A test optimizer"; }
     }
 
-    public override Mesh[] Optimize(Mesh mesh)
+    public override IScaffoldOptimizerResult[] Optimize(
+        APrimitive basePrimitive,
+        Mesh mesh,
+        Func<ulong, int, ulong> requestChildPartInstanceId
+    )
     {
-        return [new Mesh(GetVerticesTruth().ToArray(), GetIndicesTruth().ToArray(), mesh.Error)];
+        return
+        [
+            new ScaffoldOptimizerResult(
+                basePrimitive,
+                new Mesh(GetVerticesTruth().ToArray(), GetIndicesTruth().ToArray(), mesh.Error),
+                0,
+                requestChildPartInstanceId
+            )
+        ];
     }
 
     public override string[] GetPartNameTriggerKeywords()

--- a/CadRevealFbxProvider/BatchUtils/ScaffoldPartOptimizers/IScaffoldOptimizerResult.cs
+++ b/CadRevealFbxProvider/BatchUtils/ScaffoldPartOptimizers/IScaffoldOptimizerResult.cs
@@ -1,0 +1,8 @@
+namespace CadRevealFbxProvider.BatchUtils.ScaffoldPartOptimizers;
+
+using CadRevealComposer.Primitives;
+
+public interface IScaffoldOptimizerResult
+{
+    public APrimitive Get();
+}

--- a/CadRevealFbxProvider/BatchUtils/ScaffoldPartOptimizers/IScaffoldPartOptimizer.cs
+++ b/CadRevealFbxProvider/BatchUtils/ScaffoldPartOptimizers/IScaffoldPartOptimizer.cs
@@ -1,10 +1,15 @@
 namespace CadRevealFbxProvider.BatchUtils.ScaffoldPartOptimizers;
 
+using CadRevealComposer.Primitives;
 using CadRevealComposer.Tessellation;
 
 public interface IScaffoldPartOptimizer
 {
     public string Name { get; }
-    public Mesh[] Optimize(Mesh mesh);
+    public IScaffoldOptimizerResult[] Optimize(
+        APrimitive basePrimitive,                           // Primitive that contains the mesh
+        Mesh mesh,                                          // The mesh
+        Func<ulong, int, ulong> requestChildPartInstanceId  // Function will be called when the optimizer needs an instance ID parameters are (index of child mesh, instance ID of base primitive)
+    );
     public string[] GetPartNameTriggerKeywords();
 }

--- a/CadRevealFbxProvider/BatchUtils/ScaffoldPartOptimizers/ScaffoldOptimizerResult.cs
+++ b/CadRevealFbxProvider/BatchUtils/ScaffoldPartOptimizers/ScaffoldOptimizerResult.cs
@@ -1,0 +1,52 @@
+namespace CadRevealFbxProvider.BatchUtils.ScaffoldPartOptimizers;
+
+using CadRevealComposer.Primitives;
+using CadRevealComposer.Tessellation;
+
+public class ScaffoldOptimizerResult : IScaffoldOptimizerResult
+{
+    public ScaffoldOptimizerResult(
+        APrimitive basePrimitive,
+        Mesh optimizedMesh,
+        int indexChildMesh,
+        Func<ulong, int, ulong> requestChildMeshInstanceId
+    )
+    {
+        switch (basePrimitive)
+        {
+            case InstancedMesh instancedMesh:
+                ulong instanceId = requestChildMeshInstanceId(instancedMesh.InstanceId, indexChildMesh);
+                _optimizedPrimitive = new InstancedMesh(
+                    instanceId,
+                    optimizedMesh,
+                    instancedMesh.InstanceMatrix,
+                    instancedMesh.TreeIndex,
+                    instancedMesh.Color,
+                    optimizedMesh.CalculateAxisAlignedBoundingBox()
+                );
+                return;
+            case TriangleMesh triangleMesh:
+                _optimizedPrimitive = new TriangleMesh(
+                    optimizedMesh,
+                    triangleMesh.TreeIndex,
+                    triangleMesh.Color,
+                    optimizedMesh.CalculateAxisAlignedBoundingBox()
+                );
+                return;
+        }
+
+        _optimizedPrimitive = basePrimitive;
+    }
+
+    public ScaffoldOptimizerResult(APrimitive optimizedPrimitive)
+    {
+        _optimizedPrimitive = optimizedPrimitive;
+    }
+
+    public APrimitive Get()
+    {
+        return _optimizedPrimitive;
+    }
+
+    private readonly APrimitive _optimizedPrimitive;
+}


### PR DESCRIPTION
Extend the scaffold optimizer framework to enable use of primitives as results from optimizations by enable the return of an array of optimization results that contain APrimitives. The array can contain a mix of instances, triangles, or any of the available primitives.

Also, this will fix handling of instance IDs for split meshes by assigning new instance IDs for each instance mesh of a split mesh.
