### PR TITLE
Bugfix: Floor missing, wrong bounding boxes

### DIFF
--- a/CadRevealRvmProvider/Tessellation/RvmTessellator.cs
+++ b/CadRevealRvmProvider/Tessellation/RvmTessellator.cs
@@ -40,8 +40,15 @@ public class RvmTessellator
                 tessellationLogObject
             );
 
-            // Recalculating AABB, since some instances of the transformed (p.AxisAlignedBoundingBox) AABB were incorrect
-            return new TriangleMesh(mesh, p.TreeIndex, p.Color, mesh.CalculateAxisAlignedBoundingBox());
+            var boundingBox = p.AxisAlignedBoundingBox;
+            if (mesh.Vertices.Length > 0)
+            {
+                // Recalculating AABB, since some instances of the transformed (p.AxisAlignedBoundingBox) AABB were incorrect
+                // Guarded agaings meshes with zero vertices, to avoid throwing an exception
+                boundingBox = mesh.CalculateAxisAlignedBoundingBox();
+            }
+
+            return new TriangleMesh(mesh, p.TreeIndex, p.Color, boundingBox);
         }
 
         var facetGroupsNotInstanced = facetGroupInstancingResult

--- a/CadRevealRvmProvider/Tessellation/RvmTessellator.cs
+++ b/CadRevealRvmProvider/Tessellation/RvmTessellator.cs
@@ -40,7 +40,8 @@ public class RvmTessellator
                 tessellationLogObject
             );
 
-            return new TriangleMesh(mesh, p.TreeIndex, p.Color, p.AxisAlignedBoundingBox);
+            // Recalculating AABB, since some instances of the transformed (p.AxisAlignedBoundingBox) AABB were incorrect
+            return new TriangleMesh(mesh, p.TreeIndex, p.Color, mesh.CalculateAxisAlignedBoundingBox());
         }
 
         var facetGroupsNotInstanced = facetGroupInstancingResult
@@ -109,7 +110,7 @@ public class RvmTessellator
                     item.Transform,
                     item.ProtoMesh.TreeIndex,
                     item.ProtoMesh.Color,
-                    item.ProtoMesh.AxisAlignedBoundingBox
+                    group.Mesh.CalculateAxisAlignedBoundingBox(item.Transform) // Recalculating AABB, since some instances of the transformed (item.ProtoMesh.AxisAlignedBoundingBox) AABB were incorrect
                 ))
             )
             .ToArray();


### PR DESCRIPTION
Related to: [AB#188616](https://dev.azure.com/EquinorASA/13429306-9600-4820-ac5c-3e7d26fa3cb9/_workitems/edit/188616)


Some bounding boxes were wrong, and caused parts of the model to pop in and out. This happened because of some error with rotation in the input rvm data matrixes, and seemed to only happen with a few parts. 

Fix: Recalculate bounding boxes based on the mesh. This is quite fast, and does not have a noticable impact on the build times. 

![image](https://github.com/user-attachments/assets/cd57ceff-75fd-434c-863a-93814f9e4d91)
