### PR TITLE
chore(CadRevealComposerRunner): fix typo in error message

### DIFF
--- a/CadRevealComposer/CadRevealComposerRunner.cs
+++ b/CadRevealComposer/CadRevealComposerRunner.cs
@@ -267,7 +267,7 @@ public static class CadRevealComposerRunner
     {
         var json = new
         {
-            note = "This file is not considered stable api. It is meant for humans to read, not computers. See 'scene.json' for a more stable file.",
+            note = "This file is not considered a stable API. It is meant for humans to read, not computers. See `scene.json` for a more stable file.",
             modelParameters,
             composerParameters,
             timestampUtc = DateTimeOffset.UtcNow


### PR DESCRIPTION
Fixing minor typos in an error message from `CadRevealComposerRunner.cs`.