### PR TITLE
Feature/add mass and volume to scaffold metadata

### DIFF
--- a/CadRevealFbxProvider.Tests/Attributes/ScaffoldingMetadataTests.cs
+++ b/CadRevealFbxProvider.Tests/Attributes/ScaffoldingMetadataTests.cs
@@ -92,7 +92,6 @@ public class ScaffoldingMetadataTests
         metadata.TryAddValue("Work order", "1234");
         metadata.TryAddValue("Scaff build Operation number", "5678");
         metadata.TryAddValue("Dismantle Operation number", "9123");
-        metadata.TryAddValue("Size (m\u00b3)", "1423");
         metadata.TryAddValue("Grand total", "4321");
 
         // Assert
@@ -111,8 +110,7 @@ public class ScaffoldingMetadataTests
         {
             { "Work order", "1234" },
             { "Scaff build Operation number", "5678" },
-            { "Dismantle Operation number", "91011" },
-            { "Size (m\u00b3)", "121314" },
+            { "Dismantle Operation number", "91011" }
         };
 
         var targetDictIncomplete = new Dictionary<string, string>()
@@ -126,7 +124,6 @@ public class ScaffoldingMetadataTests
             { "Work order", "1234" },
             { "Scaff build Operation number", "5678" },
             { "Dismantle Operation number", "91011" },
-            { "Size (m\u00b3)", "121314" },
             { "Test entry", "4321" }
         };
 
@@ -134,8 +131,7 @@ public class ScaffoldingMetadataTests
         {
             { "Work order", "1234" },
             { "Scaff build Operation number", "" },
-            { "Dismantle Operation number", "91011" },
-            { "Size (m\u00b3)", "121314" },
+            { "Dismantle Operation number", "91011" }
         };
 
         // Assert
@@ -189,7 +185,7 @@ public class ScaffoldingMetadataTests
     }
 
     [Test]
-    public void GivenScaffoldingMetadataWeightAndVolime_WhenValuesHaveUnits_ThenOutputIsWithoutUnits()
+    public void GivenScaffoldingMetadataWeightAndVolume_WhenValuesHaveUnits_ThenOutputIsWithoutUnits()
     {
         // Arrange
         var metadataWeight1 = new ScaffoldingMetadata();

--- a/CadRevealFbxProvider.Tests/Attributes/ScaffoldingMetadataTests.cs
+++ b/CadRevealFbxProvider.Tests/Attributes/ScaffoldingMetadataTests.cs
@@ -28,20 +28,18 @@ public class ScaffoldingMetadataTests
     }
 
     [Test]
-    public void GivenMetadataKeyWeightAndVolumeWithEmptyValue_WhenCallingTryAdd_ThenReturnFalse()
+    public void GivenMetadataKeyWeightWithEmptyValue_WhenCallingTryAdd_ThenReturnFalse()
     {
         // Arrange
         var metadata = new ScaffoldingMetadata();
 
         // Act
         bool retWeight = metadata.TryAddValue("Grand total", "");
-        bool retVolume = metadata.TryAddValue("Size (m\u00b3)", "");
 
         // Assert
         Assert.Multiple(() =>
         {
             Assert.That(retWeight, Is.False);
-            Assert.That(retVolume, Is.False);
         });
     }
 
@@ -70,8 +68,8 @@ public class ScaffoldingMetadataTests
         var metadata = new ScaffoldingMetadata();
 
         // Act
-        bool retSpace = metadata.TryAddValue("Size (m\u00b3)", " ");
-        bool retCrlf = metadata.TryAddValue("Size (m\u00b3)", "\r\n");
+        bool retSpace = metadata.TryAddValue("Work order", " ");
+        bool retCrlf = metadata.TryAddValue("Work order", "\r\n");
 
         // Assert
         Assert.Multiple(() =>
@@ -108,15 +106,15 @@ public class ScaffoldingMetadataTests
         // Arrange
         var targetDictComplete = new Dictionary<string, string>()
         {
-            { "Work order", "1234" },
-            { "Scaff build Operation number", "5678" },
-            { "Dismantle Operation number", "91011" }
+            { "Work order", "1234" }
+            //            { "Scaff build Operation number", "5678" },
+            //            { "Dismantle Operation number", "91011" }
         };
 
         var targetDictIncomplete = new Dictionary<string, string>()
         {
-            { "Work order", "1234" },
-            { "Dismantle Operation number", "91011" }
+            //            { "Work order", "1234" },
+            //            { "Dismantle Operation number", "91011" }
         };
 
         var targetDictBeyondComplete = new Dictionary<string, string>()
@@ -129,9 +127,9 @@ public class ScaffoldingMetadataTests
 
         var targetDictCompleteButEmptyValue = new Dictionary<string, string>()
         {
-            { "Work order", "1234" },
-            { "Scaff build Operation number", "" },
-            { "Dismantle Operation number", "91011" }
+            { "Work order", "" }
+            //            { "Scaff build Operation number", "" },
+            //            { "Dismantle Operation number", "91011" }
         };
 
         // Assert

--- a/CadRevealFbxProvider.Tests/Attributes/ScaffoldingMetadataTests.cs
+++ b/CadRevealFbxProvider.Tests/Attributes/ScaffoldingMetadataTests.cs
@@ -165,6 +165,7 @@ public class ScaffoldingMetadataTests
     [Test]
     public void GivenAScaffoldingMetadataInstance_WhenItIsComplete_ThenTryWriteToGenericMetadataDictShouldFillTheTargetDict()
     {
+        // Arrange
         var metadata = new ScaffoldingMetadata();
         var targetDict = new Dictionary<string, string>();
 
@@ -184,6 +185,33 @@ public class ScaffoldingMetadataTests
             Assert.That(targetDict["Scaffolding_WorkOrder_DismantleOperationNumber"], Is.EqualTo("9123"));
             Assert.That(targetDict["Scaffolding_TotalVolume"], Is.EqualTo("1423"));
             Assert.That(targetDict["Scaffolding_TotalWeight"], Is.EqualTo("4321"));
+        });
+    }
+
+    [Test]
+    public void GivenScaffoldingMetadataWeightAndVolime_WhenValuesHaveUnits_ThenOutputIsWithoutUnits()
+    {
+        // Arrange
+        var metadataWeight1 = new ScaffoldingMetadata();
+        var metadataWeight2 = new ScaffoldingMetadata();
+        var metadataVolume1 = new ScaffoldingMetadata();
+
+        // Act
+        var retWeight1 = metadataWeight1.TryAddValue("Grand total", "12.34 kg");
+        var retWeight2 = metadataWeight2.TryAddValue("Grand total", "12_34e-45kg");
+        var retVolume1 = metadataVolume1.TryAddValue("Size (m\u00b3)", "567.8 m\u00b3");
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(retWeight1, Is.True);
+            Assert.That(metadataWeight1.TotalWeight, Is.EqualTo("12.34"));
+
+            Assert.That(retWeight2, Is.True);
+            Assert.That(metadataWeight2.TotalWeight, Is.EqualTo("12_34e-45"));
+
+            Assert.That(retVolume1, Is.True);
+            Assert.That(metadataVolume1.TotalVolume, Is.EqualTo("567.8"));
         });
     }
 }

--- a/CadRevealFbxProvider.Tests/Attributes/ScaffoldingMetadataTests.cs
+++ b/CadRevealFbxProvider.Tests/Attributes/ScaffoldingMetadataTests.cs
@@ -185,7 +185,7 @@ public class ScaffoldingMetadataTests
     }
 
     [Test]
-    public void GivenScaffoldingMetadataWeightAndVolume_WhenValuesHaveUnits_ThenOutputIsWithoutUnits()
+    public void GivenScaffoldingMetadataWeightAndVolume_WhenValuesHaveUnits_ThenOutputIsStillWithUnits()
     {
         // Arrange
         var metadataWeight1 = new ScaffoldingMetadata();
@@ -201,13 +201,13 @@ public class ScaffoldingMetadataTests
         Assert.Multiple(() =>
         {
             Assert.That(retWeight1, Is.True);
-            Assert.That(metadataWeight1.TotalWeight, Is.EqualTo("12.34"));
+            Assert.That(metadataWeight1.TotalWeight, Is.EqualTo("12.34 kg"));
 
             Assert.That(retWeight2, Is.True);
-            Assert.That(metadataWeight2.TotalWeight, Is.EqualTo("12_34e-45"));
+            Assert.That(metadataWeight2.TotalWeight, Is.EqualTo("12_34e-45kg"));
 
             Assert.That(retVolume1, Is.True);
-            Assert.That(metadataVolume1.TotalVolume, Is.EqualTo("567.8"));
+            Assert.That(metadataVolume1.TotalVolume, Is.EqualTo("567.8 m\u00b3"));
         });
     }
 }

--- a/CadRevealFbxProvider.Tests/Attributes/ScaffoldingMetadataTests.cs
+++ b/CadRevealFbxProvider.Tests/Attributes/ScaffoldingMetadataTests.cs
@@ -1,0 +1,189 @@
+namespace CadRevealFbxProvider.Tests.Attributes;
+
+using CadRevealFbxProvider.Attributes;
+
+[TestFixture]
+public class ScaffoldingMetadataTests
+{
+    [Test]
+    public void GivenMetadataKeyWeightAndVolumeWithValue_WhenCallingTryAdd_ThenValueIsAdded()
+    {
+        // Arrange
+        var metadataWeight = new ScaffoldingMetadata();
+        var metadataVolume = new ScaffoldingMetadata();
+
+        // Act
+        var retWeight = metadataWeight.TryAddValue("Grand total", "1234");
+        var retVolume = metadataVolume.TryAddValue("Size (m\u00b3)", "5678");
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(retWeight, Is.True);
+            Assert.That(metadataWeight.TotalWeight, Is.EqualTo("1234"));
+
+            Assert.That(retVolume, Is.True);
+            Assert.That(metadataVolume.TotalVolume, Is.EqualTo("5678"));
+        });
+    }
+
+    [Test]
+    public void GivenMetadataKeyWeightAndVolumeWithEmptyValue_WhenCallingTryAdd_ThenReturnFalse()
+    {
+        // Arrange
+        var metadata = new ScaffoldingMetadata();
+
+        // Act
+        bool retWeight = metadata.TryAddValue("Grand total", "");
+        bool retVolume = metadata.TryAddValue("Size (m\u00b3)", "");
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(retWeight, Is.False);
+            Assert.That(retVolume, Is.False);
+        });
+    }
+
+    [Test]
+    public void GivenMetadataKeyWeightWithWhiteSpaceValue_WhenCallingTryAdd_ThenReturnFalse()
+    {
+        // Arrange
+        var metadata = new ScaffoldingMetadata();
+
+        // Act
+        bool retSpace = metadata.TryAddValue("Grand total", " ");
+        bool retCrlf = metadata.TryAddValue("Grand total", "\r\n");
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(retSpace, Is.False);
+            Assert.That(retCrlf, Is.False);
+        });
+    }
+
+    [Test]
+    public void GivenMetadataKeyVolumeWithWhiteSpaceValue_WhenCallingTryAdd_ThenReturnFalse()
+    {
+        // Arrange
+        var metadata = new ScaffoldingMetadata();
+
+        // Act
+        bool retSpace = metadata.TryAddValue("Size (m\u00b3)", " ");
+        bool retCrlf = metadata.TryAddValue("Size (m\u00b3)", "\r\n");
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(retSpace, Is.False);
+            Assert.That(retCrlf, Is.False);
+        });
+    }
+
+    [Test]
+    public void GivenAScaffoldingMetadataInstance_WhenPopulatedWithMinimumOfRequiredEntries_ThenHasExpectedValuesMethodIsTrueElseFalse()
+    {
+        // Arrange
+        var metadataEmpty = new ScaffoldingMetadata();
+        var metadata = new ScaffoldingMetadata();
+
+        // Act
+        metadata.TryAddValue("Work order", "1234");
+        metadata.TryAddValue("Scaff build Operation number", "5678");
+        metadata.TryAddValue("Dismantle Operation number", "9123");
+        metadata.TryAddValue("Size (m\u00b3)", "1423");
+        metadata.TryAddValue("Grand total", "4321");
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(metadataEmpty.HasExpectedValues(), Is.False);
+            Assert.That(metadata.HasExpectedValues(), Is.True);
+        });
+    }
+
+    [Test]
+    public void GivenADictionary_WhenPopulatedWithMinimumEntries_ThenHasExpectedValuesFromAttributesPerPartMethodReturnsTrueElseFalse()
+    {
+        // Arrange
+        var targetDictComplete = new Dictionary<string, string>()
+        {
+            { "Work order", "1234" },
+            { "Scaff build Operation number", "5678" },
+            { "Dismantle Operation number", "91011" },
+            { "Size (m\u00b3)", "121314" },
+        };
+
+        var targetDictIncomplete = new Dictionary<string, string>()
+        {
+            { "Work order", "1234" },
+            { "Dismantle Operation number", "91011" }
+        };
+
+        var targetDictBeyondComplete = new Dictionary<string, string>()
+        {
+            { "Work order", "1234" },
+            { "Scaff build Operation number", "5678" },
+            { "Dismantle Operation number", "91011" },
+            { "Size (m\u00b3)", "121314" },
+            { "Test entry", "4321" }
+        };
+
+        var targetDictCompleteButEmptyValue = new Dictionary<string, string>()
+        {
+            { "Work order", "1234" },
+            { "Scaff build Operation number", "" },
+            { "Dismantle Operation number", "91011" },
+            { "Size (m\u00b3)", "121314" },
+        };
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(ScaffoldingMetadata.HasExpectedValuesFromAttributesPerPart(targetDictComplete), Is.True);
+            Assert.That(ScaffoldingMetadata.HasExpectedValuesFromAttributesPerPart(targetDictIncomplete), Is.False);
+            Assert.That(ScaffoldingMetadata.HasExpectedValuesFromAttributesPerPart(targetDictBeyondComplete), Is.True);
+            Assert.That(
+                ScaffoldingMetadata.HasExpectedValuesFromAttributesPerPart(targetDictCompleteButEmptyValue),
+                Is.False
+            );
+        });
+    }
+
+    [Test]
+    public void GivenAScaffoldingMetadataInstance_WhenItIsIncomplete_ThenTryWriteToGenericMetadataDictShouldThrow()
+    {
+        // Arrange
+        var metadataEmpty = new ScaffoldingMetadata();
+        var targetDict = new Dictionary<string, string>();
+
+        // Assert
+        Assert.Throws<Exception>(() => metadataEmpty.TryWriteToGenericMetadataDict(targetDict));
+    }
+
+    [Test]
+    public void GivenAScaffoldingMetadataInstance_WhenItIsComplete_ThenTryWriteToGenericMetadataDictShouldFillTheTargetDict()
+    {
+        var metadata = new ScaffoldingMetadata();
+        var targetDict = new Dictionary<string, string>();
+
+        // Act
+        metadata.TryAddValue("Work order", "1234");
+        metadata.TryAddValue("Scaff build Operation number", "5678");
+        metadata.TryAddValue("Dismantle Operation number", "9123");
+        metadata.TryAddValue("Size (m\u00b3)", "1423");
+        metadata.TryAddValue("Grand total", "4321");
+        metadata.TryWriteToGenericMetadataDict(targetDict);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(targetDict["Scaffolding_WorkOrder_WorkOrderNumber"], Is.EqualTo("1234"));
+            Assert.That(targetDict["Scaffolding_WorkOrder_BuildOperationNumber"], Is.EqualTo("5678"));
+            Assert.That(targetDict["Scaffolding_WorkOrder_DismantleOperationNumber"], Is.EqualTo("9123"));
+            Assert.That(targetDict["Scaffolding_TotalVolume"], Is.EqualTo("1423"));
+            Assert.That(targetDict["Scaffolding_TotalWeight"], Is.EqualTo("4321"));
+        });
+    }
+}

--- a/CadRevealFbxProvider.Tests/FbxProviderAttributeParserTests.cs
+++ b/CadRevealFbxProvider.Tests/FbxProviderAttributeParserTests.cs
@@ -36,7 +36,7 @@ public class FbxProviderAttributeParserTests
             Assert.That(metadata.HasExpectedValues());
 
             Assert.That(
-                ScaffoldingMetadata.ModelAttributesPerPart.Length + 2,
+                ScaffoldingMetadata.ModelAttributesPerPart.Length + 4,
                 Is.EqualTo(ScaffoldingMetadata.NumberOfModelAttributes)
             );
         });
@@ -257,6 +257,300 @@ public class FbxProviderAttributeParserTests
             Assert.That(ret.scaffoldingMetadata.HasExpectedValues(), Is.True);
             Assert.DoesNotThrow(() => ret.scaffoldingMetadata.TryWriteToGenericMetadataDict(targetDict));
             Assert.That(ret.scaffoldingMetadata.TotalVolume, Is.EqualTo("9.76 m\u00b3"));
+        });
+    }
+
+    [Test]
+    public void GivenLinesFromCSVFileAsStrings_WhenMissingFirstBuildOperationNumber_ThenWeHaveExpectedValuesOnReturnedMetadataAndNoThrowOnWritingToDictAndBuildOperationNumberAsResult()
+    {
+        // Arrange
+        var targetDict = new Dictionary<string, string>();
+        var fileLines = new List<string>
+        {
+            "Schedules-Export;;;",
+            "Description;Weight kg;Count;Work order;Scaff build Operation number;Dismantle Operation number;Scaff tag number;Job pack;Project number;Planned build date;Completion date;Dismantle date;Area;Discipline;Purpose;Scaff type;Load class;Size (m\u00b3);Length(m);Widht(m);Height(m);Covering (Y or N);Covering material;Last Updated;Item code",
+            ";;;;;;;;;;;;;;;;;;;;;;;;",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123451", // Line with missing build operation number
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123452",
+            "Base Element BS 600 X 34 Solid;5.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123453",
+            "Clips KF Aluhak KF 49x49;1.10 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123454",
+            "Grand total: 42;187.70 kg;;;;;;;;;;;;;;;;;;;;;;;"
+        };
+
+        // Act
+        var ret = new ScaffoldingAttributeParser().ParseAttributes(fileLines.ToArray());
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(ret.scaffoldingMetadata.HasExpectedValues(), Is.True);
+            Assert.DoesNotThrow(() => ret.scaffoldingMetadata.TryWriteToGenericMetadataDict(targetDict));
+            Assert.That(ret.scaffoldingMetadata.BuildOperationNumber, Is.EqualTo("0100"));
+        });
+    }
+
+    [Test]
+    public void GivenLinesFromCSVFileAsStrings_WhenMissingBuildOperationNumbersInBetween_ThenWeHaveExpectedValuesOnReturnedMetadataAndNoThrowOnWritingToDictAndBuildOperationNumberAsResult()
+    {
+        // Arrange
+        var targetDict = new Dictionary<string, string>();
+        var fileLines = new List<string>
+        {
+            "Schedules-Export;;;",
+            "Description;Weight kg;Count;Work order;Scaff build Operation number;Dismantle Operation number;Scaff tag number;Job pack;Project number;Planned build date;Completion date;Dismantle date;Area;Discipline;Purpose;Scaff type;Load class;Size (m\u00b3);Length(m);Widht(m);Height(m);Covering (Y or N);Covering material;Last Updated;Item code",
+            ";;;;;;;;;;;;;;;;;;;;;;;;",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123451",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123452",
+            "Base Element BS 600 X 34 Solid;5.50 kg;1;12345678;;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123453", // Line with missing build operation number
+            "Clips KF Aluhak KF 49x49;1.10 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123454",
+            "Grand total: 42;187.70 kg;;;;;;;;;;;;;;;;;;;;;;;"
+        };
+
+        // Act
+        var ret = new ScaffoldingAttributeParser().ParseAttributes(fileLines.ToArray());
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(ret.scaffoldingMetadata.HasExpectedValues(), Is.True);
+            Assert.DoesNotThrow(() => ret.scaffoldingMetadata.TryWriteToGenericMetadataDict(targetDict));
+            Assert.That(ret.scaffoldingMetadata.BuildOperationNumber, Is.EqualTo("0100"));
+        });
+    }
+
+    [Test]
+    public void GivenLinesFromCSVFileAsStrings_WhenThereAreMultipleDistinctBuildOperationNumbersInList_ThenWeHaveExpectedValuesOnReturnedMetadataAndNoThrowOnWritingToDictAndBuildOperationNumberIsEmpty()
+    {
+        // Arrange
+        var targetDict = new Dictionary<string, string>();
+        var fileLines = new List<string>
+        {
+            "Schedules-Export;;;",
+            "Description;Weight kg;Count;Work order;Scaff build Operation number;Dismantle Operation number;Scaff tag number;Job pack;Project number;Planned build date;Completion date;Dismantle date;Area;Discipline;Purpose;Scaff type;Load class;Size (m\u00b3);Length(m);Widht(m);Height(m);Covering (Y or N);Covering material;Last Updated;Item code",
+            ";;;;;;;;;;;;;;;;;;;;;;;;",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123451",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123452",
+            "Base Element BS 600 X 34 Solid;5.50 kg;1;12345678;0123;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123453",
+            "Clips KF Aluhak KF 49x49;1.10 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123454",
+            "Grand total: 42;187.70 kg;;;;;;;;;;;;;;;;;;;;;;;"
+        };
+
+        // Act
+        var ret = new ScaffoldingAttributeParser().ParseAttributes(fileLines.ToArray());
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(ret.scaffoldingMetadata.HasExpectedValues(), Is.True);
+            Assert.DoesNotThrow(() => ret.scaffoldingMetadata.TryWriteToGenericMetadataDict(targetDict));
+            Assert.That(ret.scaffoldingMetadata.BuildOperationNumber, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void GivenLinesFromCSVFileAsStrings_WhenThereAreMultipleDistinctBuildOperationNumbersAndEmptyVolumeEntryInList_ThenWeHaveExpectedValuesOnReturnedMetadataAndNoThrowOnWritingToDictAndBuildOperationNumberIsEmpty()
+    {
+        // Arrange
+        var targetDict = new Dictionary<string, string>();
+        var fileLines = new List<string>
+        {
+            "Schedules-Export;;;",
+            "Description;Weight kg;Count;Work order;Scaff build Operation number;Dismantle Operation number;Scaff tag number;Job pack;Project number;Planned build date;Completion date;Dismantle date;Area;Discipline;Purpose;Scaff type;Load class;Size (m\u00b3);Length(m);Widht(m);Height(m);Covering (Y or N);Covering material;Last Updated;Item code",
+            ";;;;;;;;;;;;;;;;;;;;;;;;",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123451",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123455", // Line with missing build operation number
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123452",
+            "Base Element BS 600 X 34 Solid;5.50 kg;1;12345678;0123;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123453",
+            "Clips KF Aluhak KF 49x49;1.10 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123454",
+            "Grand total: 42;187.70 kg;;;;;;;;;;;;;;;;;;;;;;;"
+        };
+
+        // Act
+        var ret = new ScaffoldingAttributeParser().ParseAttributes(fileLines.ToArray());
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(ret.scaffoldingMetadata.HasExpectedValues(), Is.True);
+            Assert.DoesNotThrow(() => ret.scaffoldingMetadata.TryWriteToGenericMetadataDict(targetDict));
+            Assert.That(ret.scaffoldingMetadata.BuildOperationNumber, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void GivenLinesFromCSVFileAsStrings_WhenIncludingAllBuildOperationNumberEntries_ThenWeHaveExpectedValuesOnReturnedMetadataAndNoThrowOnWritingToDictAndBuildOperationNumberAsResult()
+    {
+        // Arrange
+        var targetDict = new Dictionary<string, string>();
+        var fileLines = new List<string>
+        {
+            "Schedules-Export;;;",
+            "Description;Weight kg;Count;Work order;Scaff build Operation number;Dismantle Operation number;Scaff tag number;Job pack;Project number;Planned build date;Completion date;Dismantle date;Area;Discipline;Purpose;Scaff type;Load class;Size (m\u00b3);Length(m);Widht(m);Height(m);Covering (Y or N);Covering material;Last Updated;Item code",
+            ";;;;;;;;;;;;;;;;;;;;;;;;",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123451",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123455",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123452",
+            "Base Element BS 600 X 34 Solid;5.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123453",
+            "Clips KF Aluhak KF 49x49;1.10 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123454",
+            "Grand total: 42;187.70 kg;;;;;;;;;;;;;;;;;;;;;;;"
+        };
+
+        // Act
+        var ret = new ScaffoldingAttributeParser().ParseAttributes(fileLines.ToArray());
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(ret.scaffoldingMetadata.HasExpectedValues(), Is.True);
+            Assert.DoesNotThrow(() => ret.scaffoldingMetadata.TryWriteToGenericMetadataDict(targetDict));
+            Assert.That(ret.scaffoldingMetadata.BuildOperationNumber, Is.EqualTo("0100"));
+        });
+    }
+
+    [Test]
+    public void GivenLinesFromCSVFileAsStrings_WhenMissingFirstDismantleOperationNumber_ThenWeHaveExpectedValuesOnReturnedMetadataAndNoThrowOnWritingToDictAndDismantleOperationNumberAsResult()
+    {
+        // Arrange
+        var targetDict = new Dictionary<string, string>();
+        var fileLines = new List<string>
+        {
+            "Schedules-Export;;;",
+            "Description;Weight kg;Count;Work order;Scaff build Operation number;Dismantle Operation number;Scaff tag number;Job pack;Project number;Planned build date;Completion date;Dismantle date;Area;Discipline;Purpose;Scaff type;Load class;Size (m\u00b3);Length(m);Widht(m);Height(m);Covering (Y or N);Covering material;Last Updated;Item code",
+            ";;;;;;;;;;;;;;;;;;;;;;;;",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123451", // Line with missing dismantle operation number
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123452",
+            "Base Element BS 600 X 34 Solid;5.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123453",
+            "Clips KF Aluhak KF 49x49;1.10 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123454",
+            "Grand total: 42;187.70 kg;;;;;;;;;;;;;;;;;;;;;;;"
+        };
+
+        // Act
+        var ret = new ScaffoldingAttributeParser().ParseAttributes(fileLines.ToArray());
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(ret.scaffoldingMetadata.HasExpectedValues(), Is.True);
+            Assert.DoesNotThrow(() => ret.scaffoldingMetadata.TryWriteToGenericMetadataDict(targetDict));
+            Assert.That(ret.scaffoldingMetadata.DismantleOperationNumber, Is.EqualTo("9000"));
+        });
+    }
+
+    [Test]
+    public void GivenLinesFromCSVFileAsStrings_WhenMissingDismantleOperationNumbersInBetween_ThenWeHaveExpectedValuesOnReturnedMetadataAndNoThrowOnWritingToDictAndDismantleOperationNumberAsResult()
+    {
+        // Arrange
+        var targetDict = new Dictionary<string, string>();
+        var fileLines = new List<string>
+        {
+            "Schedules-Export;;;",
+            "Description;Weight kg;Count;Work order;Scaff build Operation number;Dismantle Operation number;Scaff tag number;Job pack;Project number;Planned build date;Completion date;Dismantle date;Area;Discipline;Purpose;Scaff type;Load class;Size (m\u00b3);Length(m);Widht(m);Height(m);Covering (Y or N);Covering material;Last Updated;Item code",
+            ";;;;;;;;;;;;;;;;;;;;;;;;",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123451",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123452",
+            "Base Element BS 600 X 34 Solid;5.50 kg;1;12345678;0100;;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123453", // Line with missing dismantle operation number
+            "Clips KF Aluhak KF 49x49;1.10 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123454",
+            "Grand total: 42;187.70 kg;;;;;;;;;;;;;;;;;;;;;;;"
+        };
+
+        // Act
+        var ret = new ScaffoldingAttributeParser().ParseAttributes(fileLines.ToArray());
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(ret.scaffoldingMetadata.HasExpectedValues(), Is.True);
+            Assert.DoesNotThrow(() => ret.scaffoldingMetadata.TryWriteToGenericMetadataDict(targetDict));
+            Assert.That(ret.scaffoldingMetadata.DismantleOperationNumber, Is.EqualTo("9000"));
+        });
+    }
+
+    [Test]
+    public void GivenLinesFromCSVFileAsStrings_WhenThereAreMultipleDistinctDismantleOperationNumbersInList_ThenWeHaveExpectedValuesOnReturnedMetadataAndNoThrowOnWritingToDictAndDismantleOperationNumberIsEmpty()
+    {
+        // Arrange
+        var targetDict = new Dictionary<string, string>();
+        var fileLines = new List<string>
+        {
+            "Schedules-Export;;;",
+            "Description;Weight kg;Count;Work order;Scaff build Operation number;Dismantle Operation number;Scaff tag number;Job pack;Project number;Planned build date;Completion date;Dismantle date;Area;Discipline;Purpose;Scaff type;Load class;Size (m\u00b3);Length(m);Widht(m);Height(m);Covering (Y or N);Covering material;Last Updated;Item code",
+            ";;;;;;;;;;;;;;;;;;;;;;;;",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123451",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123452",
+            "Base Element BS 600 X 34 Solid;5.50 kg;1;12345678;0100;12345;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123453",
+            "Clips KF Aluhak KF 49x49;1.10 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123454",
+            "Grand total: 42;187.70 kg;;;;;;;;;;;;;;;;;;;;;;;"
+        };
+
+        // Act
+        var ret = new ScaffoldingAttributeParser().ParseAttributes(fileLines.ToArray());
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(ret.scaffoldingMetadata.HasExpectedValues(), Is.True);
+            Assert.DoesNotThrow(() => ret.scaffoldingMetadata.TryWriteToGenericMetadataDict(targetDict));
+            Assert.That(ret.scaffoldingMetadata.DismantleOperationNumber, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void GivenLinesFromCSVFileAsStrings_WhenThereAreMultipleDistinctDismantleOperationNumbersAndEmptyVolumeEntryInList_ThenWeHaveExpectedValuesOnReturnedMetadataAndNoThrowOnWritingToDictAndDismantleOperationNumberIsEmpty()
+    {
+        // Arrange
+        var targetDict = new Dictionary<string, string>();
+        var fileLines = new List<string>
+        {
+            "Schedules-Export;;;",
+            "Description;Weight kg;Count;Work order;Scaff build Operation number;Dismantle Operation number;Scaff tag number;Job pack;Project number;Planned build date;Completion date;Dismantle date;Area;Discipline;Purpose;Scaff type;Load class;Size (m\u00b3);Length(m);Widht(m);Height(m);Covering (Y or N);Covering material;Last Updated;Item code",
+            ";;;;;;;;;;;;;;;;;;;;;;;;",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123451",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123455", // Line with missing dismantle operation number
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123452",
+            "Base Element BS 600 X 34 Solid;5.50 kg;1;12345678;0100;12345;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123453",
+            "Clips KF Aluhak KF 49x49;1.10 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123454",
+            "Grand total: 42;187.70 kg;;;;;;;;;;;;;;;;;;;;;;;"
+        };
+
+        // Act
+        var ret = new ScaffoldingAttributeParser().ParseAttributes(fileLines.ToArray());
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(ret.scaffoldingMetadata.HasExpectedValues(), Is.True);
+            Assert.DoesNotThrow(() => ret.scaffoldingMetadata.TryWriteToGenericMetadataDict(targetDict));
+            Assert.That(ret.scaffoldingMetadata.DismantleOperationNumber, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void GivenLinesFromCSVFileAsStrings_WhenIncludingAllDismantleOperationNumberEntries_ThenWeHaveExpectedValuesOnReturnedMetadataAndNoThrowOnWritingToDictAndDismantleOperationNumberAsResult()
+    {
+        // Arrange
+        var targetDict = new Dictionary<string, string>();
+        var fileLines = new List<string>
+        {
+            "Schedules-Export;;;",
+            "Description;Weight kg;Count;Work order;Scaff build Operation number;Dismantle Operation number;Scaff tag number;Job pack;Project number;Planned build date;Completion date;Dismantle date;Area;Discipline;Purpose;Scaff type;Load class;Size (m\u00b3);Length(m);Widht(m);Height(m);Covering (Y or N);Covering material;Last Updated;Item code",
+            ";;;;;;;;;;;;;;;;;;;;;;;;",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123451",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123455",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123452",
+            "Base Element BS 600 X 34 Solid;5.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123453",
+            "Clips KF Aluhak KF 49x49;1.10 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123454",
+            "Grand total: 42;187.70 kg;;;;;;;;;;;;;;;;;;;;;;;"
+        };
+
+        // Act
+        var ret = new ScaffoldingAttributeParser().ParseAttributes(fileLines.ToArray());
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(ret.scaffoldingMetadata.HasExpectedValues(), Is.True);
+            Assert.DoesNotThrow(() => ret.scaffoldingMetadata.TryWriteToGenericMetadataDict(targetDict));
+            Assert.That(ret.scaffoldingMetadata.DismantleOperationNumber, Is.EqualTo("9000"));
         });
     }
 }

--- a/CadRevealFbxProvider.Tests/FbxProviderAttributeParserTests.cs
+++ b/CadRevealFbxProvider.Tests/FbxProviderAttributeParserTests.cs
@@ -1,6 +1,6 @@
 ﻿namespace CadRevealFbxProvider.Tests;
 
-using Attributes;
+using CadRevealFbxProvider.Attributes;
 using NUnit.Framework;
 
 [TestFixture]

--- a/CadRevealFbxProvider.Tests/FbxProviderAttributeParserTests.cs
+++ b/CadRevealFbxProvider.Tests/FbxProviderAttributeParserTests.cs
@@ -138,7 +138,7 @@ public class FbxProviderAttributeParserTests
         {
             Assert.That(ret.scaffoldingMetadata.HasExpectedValues(), Is.True);
             Assert.DoesNotThrow(() => ret.scaffoldingMetadata.TryWriteToGenericMetadataDict(targetDict));
-            Assert.That(ret.scaffoldingMetadata.TotalVolume, Is.EqualTo("9.76"));
+            Assert.That(ret.scaffoldingMetadata.TotalVolume, Is.EqualTo("9.76 m\u00b3"));
         });
     }
 
@@ -167,7 +167,7 @@ public class FbxProviderAttributeParserTests
         {
             Assert.That(ret.scaffoldingMetadata.HasExpectedValues(), Is.True);
             Assert.DoesNotThrow(() => ret.scaffoldingMetadata.TryWriteToGenericMetadataDict(targetDict));
-            Assert.That(ret.scaffoldingMetadata.TotalVolume, Is.EqualTo("9.76"));
+            Assert.That(ret.scaffoldingMetadata.TotalVolume, Is.EqualTo("9.76 m\u00b3"));
         });
     }
 
@@ -240,7 +240,7 @@ public class FbxProviderAttributeParserTests
         {
             Assert.That(ret.scaffoldingMetadata.HasExpectedValues(), Is.True);
             Assert.DoesNotThrow(() => ret.scaffoldingMetadata.TryWriteToGenericMetadataDict(targetDict));
-            Assert.That(ret.scaffoldingMetadata.TotalVolume, Is.EqualTo("9.76"));
+            Assert.That(ret.scaffoldingMetadata.TotalVolume, Is.EqualTo("9.76 m\u00b3"));
         });
     }
 }

--- a/CadRevealFbxProvider.Tests/FbxProviderAttributeParserTests.cs
+++ b/CadRevealFbxProvider.Tests/FbxProviderAttributeParserTests.cs
@@ -28,14 +28,18 @@ public class FbxProviderAttributeParserTests
                 countNodesWithMissingAttrib++;
             }
         }
-        // expects three lines with missing attributes
-        Assert.That(countNodesWithMissingAttrib, Is.EqualTo(3));
-        Assert.That(metadata.HasExpectedValues());
 
-        Assert.That(
-            ScaffoldingMetadata.ModelAttributesPerPart.Length + 1,
-            Is.EqualTo(ScaffoldingMetadata.NumberOfModelAttributes)
-        );
+        Assert.Multiple(() =>
+        {
+            // expects three lines with missing attributes
+            Assert.That(countNodesWithMissingAttrib, Is.EqualTo(3));
+            Assert.That(metadata.HasExpectedValues());
+
+            Assert.That(
+                ScaffoldingMetadata.ModelAttributesPerPart.Length + 2,
+                Is.EqualTo(ScaffoldingMetadata.NumberOfModelAttributes)
+            );
+        });
     }
 
     [Test]
@@ -78,5 +82,165 @@ public class FbxProviderAttributeParserTests
             },
             "Was expecting an exception saying that the attribute count is off, but got none"
         );
+    }
+
+    [Test]
+    public void GivenLinesFromCSVFileAsStrings_WhenNotIncludingAnyVolume_ThenWeHaveExpectedValuesOnReturnedMetadataAndNoThrowOnWritingToDictAndVolumeIsEmpty()
+    {
+        // Arrange
+        var targetDict = new Dictionary<string, string>();
+        var fileLines = new List<string>
+        {
+            "Schedules-Export;;;",
+            "Description;Weight kg;Count;Work order;Scaff build Operation number;Dismantle Operation number;Scaff tag number;Job pack;Project number;Planned build date;Completion date;Dismantle date;Area;Discipline;Purpose;Scaff type;Load class;Size (m\u00b3);Length(m);Widht(m);Height(m);Covering (Y or N);Covering material;Last Updated;Item code",
+            ";;;;;;;;;;;;;;;;;;;;;;;;",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;;;;;;;;123451",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;;;;;;;;123452",
+            "Base Element BS 600 X 34 Solid;5.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;;;;;;;;123453",
+            "Clips KF Aluhak KF 49x49;1.10 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;;;;;;;;123454",
+            "Grand total: 42;187.70 kg;;;;;;;;;;;;;;;;;;;;;;;"
+        };
+
+        // Act
+        var ret = new ScaffoldingAttributeParser().ParseAttributes(fileLines.ToArray());
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(ret.scaffoldingMetadata.HasExpectedValues(), Is.True);
+            Assert.DoesNotThrow(() => ret.scaffoldingMetadata.TryWriteToGenericMetadataDict(targetDict));
+            Assert.That(ret.scaffoldingMetadata.TotalVolume, Is.Null);
+        });
+    }
+
+    [Test]
+    public void GivenLinesFromCSVFileAsStrings_WhenMissingFirstVolume_ThenWeHaveExpectedValuesOnReturnedMetadataAndNoThrowOnWritingToDictAndVolumeAsResult()
+    {
+        // Arrange
+        var targetDict = new Dictionary<string, string>();
+        var fileLines = new List<string>
+        {
+            "Schedules-Export;;;",
+            "Description;Weight kg;Count;Work order;Scaff build Operation number;Dismantle Operation number;Scaff tag number;Job pack;Project number;Planned build date;Completion date;Dismantle date;Area;Discipline;Purpose;Scaff type;Load class;Size (m\u00b3);Length(m);Widht(m);Height(m);Covering (Y or N);Covering material;Last Updated;Item code",
+            ";;;;;;;;;;;;;;;;;;;;;;;;",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;;;;;;;;123451", // Line with missing volume
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123452",
+            "Base Element BS 600 X 34 Solid;5.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123453",
+            "Clips KF Aluhak KF 49x49;1.10 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123454",
+            "Grand total: 42;187.70 kg;;;;;;;;;;;;;;;;;;;;;;;"
+        };
+
+        // Act
+        var ret = new ScaffoldingAttributeParser().ParseAttributes(fileLines.ToArray());
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(ret.scaffoldingMetadata.HasExpectedValues(), Is.True);
+            Assert.DoesNotThrow(() => ret.scaffoldingMetadata.TryWriteToGenericMetadataDict(targetDict));
+            Assert.That(ret.scaffoldingMetadata.TotalVolume, Is.EqualTo("9.76"));
+        });
+    }
+
+    [Test]
+    public void GivenLinesFromCSVFileAsStrings_WhenMissingVolumeInBetween_ThenWeHaveExpectedValuesOnReturnedMetadataAndNoThrowOnWritingToDictAndVolumeAsResult()
+    {
+        // Arrange
+        var targetDict = new Dictionary<string, string>();
+        var fileLines = new List<string>
+        {
+            "Schedules-Export;;;",
+            "Description;Weight kg;Count;Work order;Scaff build Operation number;Dismantle Operation number;Scaff tag number;Job pack;Project number;Planned build date;Completion date;Dismantle date;Area;Discipline;Purpose;Scaff type;Load class;Size (m\u00b3);Length(m);Widht(m);Height(m);Covering (Y or N);Covering material;Last Updated;Item code",
+            ";;;;;;;;;;;;;;;;;;;;;;;;",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123451",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123452",
+            "Base Element BS 600 X 34 Solid;5.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;;;;;;;;123453", // Line with missing volume
+            "Clips KF Aluhak KF 49x49;1.10 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123454",
+            "Grand total: 42;187.70 kg;;;;;;;;;;;;;;;;;;;;;;;"
+        };
+
+        // Act
+        var ret = new ScaffoldingAttributeParser().ParseAttributes(fileLines.ToArray());
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(ret.scaffoldingMetadata.HasExpectedValues(), Is.True);
+            Assert.DoesNotThrow(() => ret.scaffoldingMetadata.TryWriteToGenericMetadataDict(targetDict));
+            Assert.That(ret.scaffoldingMetadata.TotalVolume, Is.EqualTo("9.76"));
+        });
+    }
+
+    [Test]
+    public void GivenLinesFromCSVFileAsStrings_WhenThereAreMultipleDistinctVolumesInList_ThenThrowOnAttributeParsing()
+    {
+        // Arrange
+        var targetDict = new Dictionary<string, string>();
+        var fileLines = new List<string>
+        {
+            "Schedules-Export;;;",
+            "Description;Weight kg;Count;Work order;Scaff build Operation number;Dismantle Operation number;Scaff tag number;Job pack;Project number;Planned build date;Completion date;Dismantle date;Area;Discipline;Purpose;Scaff type;Load class;Size (m\u00b3);Length(m);Widht(m);Height(m);Covering (Y or N);Covering material;Last Updated;Item code",
+            ";;;;;;;;;;;;;;;;;;;;;;;;",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123451",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123452",
+            "Base Element BS 600 X 34 Solid;5.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;3.98 m\u00b3;;;;;;;123453",
+            "Clips KF Aluhak KF 49x49;1.10 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123454",
+            "Grand total: 42;187.70 kg;;;;;;;;;;;;;;;;;;;;;;;"
+        };
+
+        // Act + Assert
+        Assert.Throws<Exception>(() => new ScaffoldingAttributeParser().ParseAttributes(fileLines.ToArray()));
+    }
+
+    [Test]
+    public void GivenLinesFromCSVFileAsStrings_WhenThereAreMultipleDistinctVolumesAndEmptyVolumeEntryInList_ThenThrowOnAttributeParsing()
+    {
+        // Arrange
+        var targetDict = new Dictionary<string, string>();
+        var fileLines = new List<string>
+        {
+            "Schedules-Export;;;",
+            "Description;Weight kg;Count;Work order;Scaff build Operation number;Dismantle Operation number;Scaff tag number;Job pack;Project number;Planned build date;Completion date;Dismantle date;Area;Discipline;Purpose;Scaff type;Load class;Size (m\u00b3);Length(m);Widht(m);Height(m);Covering (Y or N);Covering material;Last Updated;Item code",
+            ";;;;;;;;;;;;;;;;;;;;;;;;",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123451",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;;;;;;;;123455", // Line with missing volume
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123452",
+            "Base Element BS 600 X 34 Solid;5.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;3.98 m\u00b3;;;;;;;123453",
+            "Clips KF Aluhak KF 49x49;1.10 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123454",
+            "Grand total: 42;187.70 kg;;;;;;;;;;;;;;;;;;;;;;;"
+        };
+
+        // Act + Assert
+        Assert.Throws<Exception>(() => new ScaffoldingAttributeParser().ParseAttributes(fileLines.ToArray()));
+    }
+
+    [Test]
+    public void GivenLinesFromCSVFileAsStrings_WhenIncludingAllVolumeEntries_ThenWeHaveExpectedValuesOnReturnedMetadataAndNoThrowOnWritingToDictAndVolumeAsResult()
+    {
+        // Arrange
+        var targetDict = new Dictionary<string, string>();
+        var fileLines = new List<string>
+        {
+            "Schedules-Export;;;",
+            "Description;Weight kg;Count;Work order;Scaff build Operation number;Dismantle Operation number;Scaff tag number;Job pack;Project number;Planned build date;Completion date;Dismantle date;Area;Discipline;Purpose;Scaff type;Load class;Size (m\u00b3);Length(m);Widht(m);Height(m);Covering (Y or N);Covering material;Last Updated;Item code",
+            ";;;;;;;;;;;;;;;;;;;;;;;;",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123451",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123455",
+            "Alu Pipe 48,3 X 1,50;1.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123452",
+            "Base Element BS 600 X 34 Solid;5.50 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123453",
+            "Clips KF Aluhak KF 49x49;1.10 kg;1;12345678;0100;9000;;;;;;;;;56-LD-0026;;;9.76 m\u00b3;;;;;;;123454",
+            "Grand total: 42;187.70 kg;;;;;;;;;;;;;;;;;;;;;;;"
+        };
+
+        // Act
+        var ret = new ScaffoldingAttributeParser().ParseAttributes(fileLines.ToArray());
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(ret.scaffoldingMetadata.HasExpectedValues(), Is.True);
+            Assert.DoesNotThrow(() => ret.scaffoldingMetadata.TryWriteToGenericMetadataDict(targetDict));
+            Assert.That(ret.scaffoldingMetadata.TotalVolume, Is.EqualTo("9.76"));
+        });
     }
 }

--- a/CadRevealFbxProvider.Tests/FbxProviderAttributeParserTests.cs
+++ b/CadRevealFbxProvider.Tests/FbxProviderAttributeParserTests.cs
@@ -172,7 +172,7 @@ public class FbxProviderAttributeParserTests
     }
 
     [Test]
-    public void GivenLinesFromCSVFileAsStrings_WhenThereAreMultipleDistinctVolumesInList_ThenThrowOnAttributeParsing()
+    public void GivenLinesFromCSVFileAsStrings_WhenThereAreMultipleDistinctVolumesInList_ThenWeHaveExpectedValuesOnReturnedMetadataAndNoThrowOnWritingToDictAndVolumeIsEmpty()
     {
         // Arrange
         var targetDict = new Dictionary<string, string>();
@@ -188,12 +188,20 @@ public class FbxProviderAttributeParserTests
             "Grand total: 42;187.70 kg;;;;;;;;;;;;;;;;;;;;;;;"
         };
 
-        // Act + Assert
-        Assert.Throws<Exception>(() => new ScaffoldingAttributeParser().ParseAttributes(fileLines.ToArray()));
+        // Act
+        var ret = new ScaffoldingAttributeParser().ParseAttributes(fileLines.ToArray());
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(ret.scaffoldingMetadata.HasExpectedValues(), Is.True);
+            Assert.DoesNotThrow(() => ret.scaffoldingMetadata.TryWriteToGenericMetadataDict(targetDict));
+            Assert.That(ret.scaffoldingMetadata.TotalVolume, Is.Empty);
+        });
     }
 
     [Test]
-    public void GivenLinesFromCSVFileAsStrings_WhenThereAreMultipleDistinctVolumesAndEmptyVolumeEntryInList_ThenThrowOnAttributeParsing()
+    public void GivenLinesFromCSVFileAsStrings_WhenThereAreMultipleDistinctVolumesAndEmptyVolumeEntryInList_ThenWeHaveExpectedValuesOnReturnedMetadataAndNoThrowOnWritingToDictAndVolumeIsEmpty()
     {
         // Arrange
         var targetDict = new Dictionary<string, string>();
@@ -210,8 +218,16 @@ public class FbxProviderAttributeParserTests
             "Grand total: 42;187.70 kg;;;;;;;;;;;;;;;;;;;;;;;"
         };
 
-        // Act + Assert
-        Assert.Throws<Exception>(() => new ScaffoldingAttributeParser().ParseAttributes(fileLines.ToArray()));
+        // Act
+        var ret = new ScaffoldingAttributeParser().ParseAttributes(fileLines.ToArray());
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(ret.scaffoldingMetadata.HasExpectedValues(), Is.True);
+            Assert.DoesNotThrow(() => ret.scaffoldingMetadata.TryWriteToGenericMetadataDict(targetDict));
+            Assert.That(ret.scaffoldingMetadata.TotalVolume, Is.Empty);
+        });
     }
 
     [Test]

--- a/CadRevealFbxProvider.Tests/FbxProviderAttributeParserTests.cs
+++ b/CadRevealFbxProvider.Tests/FbxProviderAttributeParserTests.cs
@@ -109,7 +109,7 @@ public class FbxProviderAttributeParserTests
         {
             Assert.That(ret.scaffoldingMetadata.HasExpectedValues(), Is.True);
             Assert.DoesNotThrow(() => ret.scaffoldingMetadata.TryWriteToGenericMetadataDict(targetDict));
-            Assert.That(ret.scaffoldingMetadata.TotalVolume, Is.Null);
+            Assert.That(ret.scaffoldingMetadata.TotalVolume, Is.Empty);
         });
     }
 

--- a/CadRevealFbxProvider.Tests/FbxProviderTests.cs
+++ b/CadRevealFbxProvider.Tests/FbxProviderTests.cs
@@ -2,13 +2,13 @@ namespace CadRevealFbxProvider.Tests;
 
 using System.Drawing;
 using System.Numerics;
-using Attributes;
 using CadRevealComposer;
 using CadRevealComposer.Configuration;
 using CadRevealComposer.IdProviders;
 using CadRevealComposer.ModelFormatProvider;
 using CadRevealComposer.Operations;
 using CadRevealComposer.Primitives;
+using CadRevealFbxProvider.Attributes;
 using CadRevealFbxProvider.BatchUtils;
 
 [TestFixture]

--- a/CadRevealFbxProvider/Attributes/ScaffoldingAttributeParser.cs
+++ b/CadRevealFbxProvider/Attributes/ScaffoldingAttributeParser.cs
@@ -12,6 +12,11 @@ public class ScaffoldingAttributeParser
 
     public static readonly int NumberOfAttributesPerPart = 23; // all attributes including 3 out of 4 model attributes
 
+    private static string ConvertStringToEmptyIfNullOrWhiteSpace(string? s)
+    {
+        return string.IsNullOrWhiteSpace(s) ? "" : s;
+    }
+
     public (
         Dictionary<string, Dictionary<string, string>?> attributesDictionary,
         ScaffoldingMetadata scaffoldingMetadata
@@ -98,6 +103,10 @@ public class ScaffoldingAttributeParser
                 "Missing expected metadata: " + JsonSerializer.Serialize(entireScaffoldingMetadata)
             );
         }
+
+        entireScaffoldingMetadata.TotalVolume = ConvertStringToEmptyIfNullOrWhiteSpace(
+            entireScaffoldingMetadata.TotalVolume
+        );
 
         return (attributesDictionary, entireScaffoldingMetadata);
     }

--- a/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
+++ b/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
@@ -61,24 +61,6 @@ public class ScaffoldingMetadata
             );
     }
 
-    private string StripUnit(string stringWithUnit)
-    {
-        string strippedString = "";
-        bool lastDigitFound = false;
-        foreach (var c in stringWithUnit)
-        {
-            if (!lastDigitFound && IsNumber(c))
-                strippedString += c;
-            else
-                lastDigitFound = true;
-        }
-
-        return strippedString;
-
-        bool IsNumber(char c) =>
-            char.IsNumber(c) || char.IsPunctuation(c) || c == 'e' || c == '_' || c == '\'' || c == '+' || c == '-';
-    }
-
     public bool TryAddValue(string key, string value)
     {
         if (!ColumnToAttributeMap.ContainsKey(key))
@@ -102,12 +84,10 @@ public class ScaffoldingMetadata
                     DismantleOperationNumber = value;
                     break;
                 case AttributeEnum.TotalVolume:
-                    value = StripUnit(value);
                     GuardForInvalidValues(value, TotalVolume);
                     TotalVolume = value;
                     break;
                 case AttributeEnum.TotalWeight:
-                    value = StripUnit(value);
                     GuardForInvalidValues(value, TotalWeight);
                     TotalWeight = value;
                     break;

--- a/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
+++ b/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
@@ -1,6 +1,7 @@
 ﻿namespace CadRevealFbxProvider.Attributes;
 
 using System.Collections.Generic;
+using System.Numerics;
 
 public class ScaffoldingMetadata
 {
@@ -61,6 +62,24 @@ public class ScaffoldingMetadata
             );
     }
 
+    private string StripUnit(string stringWithUnit)
+    {
+        string strippedString = "";
+        bool lastDigitFound = false;
+        foreach (var c in stringWithUnit)
+        {
+            if (!lastDigitFound && IsNumber(c))
+                strippedString += c;
+            else
+                lastDigitFound = true;
+        }
+
+        return strippedString;
+
+        bool IsNumber(char c) =>
+            char.IsNumber(c) || char.IsPunctuation(c) || c == 'e' || c == '_' || c == '\'' || c == '+' || c == '-';
+    }
+
     public bool TryAddValue(string key, string value)
     {
         if (!ColumnToAttributeMap.ContainsKey(key))
@@ -84,10 +103,12 @@ public class ScaffoldingMetadata
                     DismantleOperationNumber = value;
                     break;
                 case AttributeEnum.TotalVolume:
+                    value = StripUnit(value);
                     GuardForInvalidValues(value, TotalVolume);
                     TotalVolume = value;
                     break;
                 case AttributeEnum.TotalWeight:
+                    value = StripUnit(value);
                     GuardForInvalidValues(value, TotalWeight);
                     TotalWeight = value;
                     break;

--- a/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
+++ b/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
@@ -19,9 +19,9 @@ public class ScaffoldingMetadata
 
     public static readonly string[] ModelAttributesPerPart =
     {
-        "Work order",
-        "Scaff build Operation number",
-        "Dismantle Operation number"
+        "Work order"
+        //        "Scaff build Operation number",
+        //        "Dismantle Operation number"
     };
 
     public static readonly int NumberOfModelAttributes = Enum.GetNames(typeof(AttributeEnum)).Length;
@@ -66,14 +66,18 @@ public class ScaffoldingMetadata
         return mappedKey switch
         {
             AttributeEnum.TotalVolume => true,
+            AttributeEnum.BuildOperationId => true,
+            AttributeEnum.DismantleOperationId => true,
             _ => false
         };
     }
 
     private static string? MakeStringEmptyIfDuplicate(string newValue, string? existingValue)
     {
-        if (newValue == "") return existingValue;
-        if (existingValue == null) return newValue;
+        if (newValue == "")
+            return existingValue;
+        if (existingValue == null)
+            return newValue;
         return (newValue != existingValue) ? "" : newValue;
     }
 
@@ -92,12 +96,10 @@ public class ScaffoldingMetadata
                     WorkOrder = value;
                     break;
                 case AttributeEnum.BuildOperationId:
-                    GuardForInvalidValues(value, BuildOperationNumber);
-                    BuildOperationNumber = value;
+                    BuildOperationNumber = MakeStringEmptyIfDuplicate(value, BuildOperationNumber);
                     break;
                 case AttributeEnum.DismantleOperationId:
-                    GuardForInvalidValues(value, DismantleOperationNumber);
-                    DismantleOperationNumber = value;
+                    DismantleOperationNumber = MakeStringEmptyIfDuplicate(value, DismantleOperationNumber);
                     break;
                 case AttributeEnum.TotalVolume:
                     TotalVolume = MakeStringEmptyIfDuplicate(value, TotalVolume);
@@ -121,8 +123,8 @@ public class ScaffoldingMetadata
         if (
             // Do not include PlannedBuildDate, CompletionDate, and DismantleDate here, since these may be allowed empty
             string.IsNullOrEmpty(WorkOrder)
-            || string.IsNullOrEmpty(BuildOperationNumber)
-            || string.IsNullOrEmpty(DismantleOperationNumber)
+            //            || string.IsNullOrEmpty(BuildOperationNumber)
+            //            || string.IsNullOrEmpty(DismantleOperationNumber)
             || string.IsNullOrEmpty(TotalWeight)
         )
         {

--- a/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
+++ b/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
@@ -21,8 +21,7 @@ public class ScaffoldingMetadata
     {
         "Work order",
         "Scaff build Operation number",
-        "Dismantle Operation number",
-        "Size (m\u00b3)"
+        "Dismantle Operation number"
     };
 
     public static readonly int NumberOfModelAttributes = Enum.GetNames(typeof(AttributeEnum)).Length;
@@ -129,7 +128,6 @@ public class ScaffoldingMetadata
             string.IsNullOrEmpty(WorkOrder)
             || string.IsNullOrEmpty(BuildOperationNumber)
             || string.IsNullOrEmpty(DismantleOperationNumber)
-            || string.IsNullOrEmpty(TotalVolume)
             || string.IsNullOrEmpty(TotalWeight)
         )
         {

--- a/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
+++ b/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
@@ -61,13 +61,29 @@ public class ScaffoldingMetadata
             );
     }
 
+    private static bool OverrideNullOrWhiteSpaceCheck(AttributeEnum mappedKey)
+    {
+        return mappedKey switch
+        {
+            AttributeEnum.TotalVolume => true,
+            _ => false
+        };
+    }
+
+    private static string? MakeStringEmptyIfDuplicate(string newValue, string? existingValue)
+    {
+        if (newValue == "") return existingValue;
+        if (existingValue == null) return newValue;
+        return (newValue != existingValue) ? "" : newValue;
+    }
+
     public bool TryAddValue(string key, string value)
     {
         if (!ColumnToAttributeMap.ContainsKey(key))
             return false;
 
         var mappedKey = ColumnToAttributeMap[key];
-        if (!string.IsNullOrWhiteSpace(value))
+        if (!string.IsNullOrWhiteSpace(value) || OverrideNullOrWhiteSpaceCheck(mappedKey))
         {
             switch (mappedKey)
             {
@@ -84,8 +100,7 @@ public class ScaffoldingMetadata
                     DismantleOperationNumber = value;
                     break;
                 case AttributeEnum.TotalVolume:
-                    GuardForInvalidValues(value, TotalVolume);
-                    TotalVolume = value;
+                    TotalVolume = MakeStringEmptyIfDuplicate(value, TotalVolume);
                     break;
                 case AttributeEnum.TotalWeight:
                     GuardForInvalidValues(value, TotalWeight);

--- a/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
+++ b/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
@@ -7,31 +7,35 @@ public class ScaffoldingMetadata
     public string? WorkOrder { get; set; }
     public string? BuildOperationNumber { get; set; }
     public string? DismantleOperationNumber { get; set; }
+    public string? TotalVolume { get; set; }
     public string? TotalWeight { get; set; }
 
-    public const string WorkOrderFieldName = "Scaffolding_WorkOrder_WorkOrderNumber";
-    public const string BuildOpFieldName = "Scaffolding_WorkOrder_BuildOperationNumber";
-    public const string DismantleOpFieldName = "Scaffolding_WorkOrder_DismantleOperationNumber";
-    public const string TotalWeightFieldName = "Scaffolding_TotalWeight";
+    private const string WorkOrderFieldName = "Scaffolding_WorkOrder_WorkOrderNumber";
+    private const string BuildOpFieldName = "Scaffolding_WorkOrder_BuildOperationNumber";
+    private const string DismantleOpFieldName = "Scaffolding_WorkOrder_DismantleOperationNumber";
+    private const string TotalVolumeFieldName = "Scaffolding_TotalVolume";
+    private const string TotalWeightFieldName = "Scaffolding_TotalWeight";
 
     public static readonly string[] ModelAttributesPerPart =
     {
         "Work order",
         "Scaff build Operation number",
-        "Dismantle Operation number"
+        "Dismantle Operation number",
+        "Size (m\u00b3)"
     };
 
     public static readonly int NumberOfModelAttributes = Enum.GetNames(typeof(AttributeEnum)).Length;
 
-    public enum AttributeEnum
+    private enum AttributeEnum
     {
         WorkOrderId,
         BuildOperationId,
         DismantleOperationId,
+        TotalVolume,
         TotalWeight
     }
 
-    public static readonly Dictionary<string, AttributeEnum> ColumnToAttributeMap = new Dictionary<
+    private static readonly Dictionary<string, AttributeEnum> ColumnToAttributeMap = new Dictionary<
         string,
         AttributeEnum
     >
@@ -39,10 +43,11 @@ public class ScaffoldingMetadata
         { "Work order", AttributeEnum.WorkOrderId },
         { "Scaff build Operation number", AttributeEnum.BuildOperationId },
         { "Dismantle Operation number", AttributeEnum.DismantleOperationId },
+        { "Size (m\u00b3)", AttributeEnum.TotalVolume },
         { "Grand total", AttributeEnum.TotalWeight }
     };
 
-    public void GuardForInvalidValues(string newValue, string? existingValue)
+    private static void GuardForInvalidValues(string newValue, string? existingValue)
     {
         if (newValue == existingValue)
             return;
@@ -78,6 +83,10 @@ public class ScaffoldingMetadata
                     GuardForInvalidValues(value, DismantleOperationNumber);
                     DismantleOperationNumber = value;
                     break;
+                case AttributeEnum.TotalVolume:
+                    GuardForInvalidValues(value, TotalVolume);
+                    TotalVolume = value;
+                    break;
                 case AttributeEnum.TotalWeight:
                     GuardForInvalidValues(value, TotalWeight);
                     TotalWeight = value;
@@ -99,6 +108,7 @@ public class ScaffoldingMetadata
             string.IsNullOrEmpty(WorkOrder)
             || string.IsNullOrEmpty(BuildOperationNumber)
             || string.IsNullOrEmpty(DismantleOperationNumber)
+            || string.IsNullOrEmpty(TotalVolume)
             || string.IsNullOrEmpty(TotalWeight)
         )
         {
@@ -128,10 +138,11 @@ public class ScaffoldingMetadata
         if (!HasExpectedValues())
             throw new Exception("Cannot write metadata: invalid content");
 
-        // the if above ensures that the fields and not null
+        // The if above ensures that the fields are not null
         targetDict.Add(WorkOrderFieldName, WorkOrder!);
         targetDict.Add(BuildOpFieldName, BuildOperationNumber!);
         targetDict.Add(DismantleOpFieldName, DismantleOperationNumber!);
+        targetDict.Add(TotalVolumeFieldName, TotalVolume!);
         targetDict.Add(TotalWeightFieldName, TotalWeight!);
     }
 }


### PR DESCRIPTION
This will pass through the volume metadata present in the scaffold metadata CSV file to the  modelMetadata.json file. The following logic holds and can be a guide for how to test the feature, if required:

* Given a CSV file, when not including any volume, then we have an empty string volume output
* Given a CSV file, when missing the first volume, then we have a string containing the volume, which is the same as the volume entries in the CSV that are not empty
*Given a CSV file, when missing volumes in-between, then we have a string containing the volume, which is the same as the volume entries in the CSV that are not empty
* Given a CSV file, when there are multiple distinct volumes in the CSV file, then we throw an exception and abort
* Given a CSV file, when there are multiple distinct volumes and empty volume entries in the CSV file, then we throw an exception and abort
* Given a CSV file, when including all volume entries, then we have a string containing the volume, which is the same as the volume entries in the CSV that are now all the same
