### PR TITLE
Skip meshes with zero vertices (FBX loading)

### DIFF
--- a/CadRevealFbxProvider/FbxNodeToCadRevealNodeConverter.cs
+++ b/CadRevealFbxProvider/FbxNodeToCadRevealNodeConverter.cs
@@ -180,14 +180,9 @@ public static class FbxNodeToCadRevealNodeConverter
             return instancedMesh;
         }
 
-
         if (mesh.Vertices.Length == 0)
         {
-            Console.Error.WriteLine(
-                "Found mesh with zero vertices: "
-                    + node.GetNodeName()
-                    + ". (ignoring). "
-            );
+            Console.Error.WriteLine("Found mesh with zero vertices: " + node.GetNodeName() + ". (ignoring). ");
             return null;
         }
 

--- a/CadRevealFbxProvider/FbxNodeToCadRevealNodeConverter.cs
+++ b/CadRevealFbxProvider/FbxNodeToCadRevealNodeConverter.cs
@@ -180,6 +180,17 @@ public static class FbxNodeToCadRevealNodeConverter
             return instancedMesh;
         }
 
+
+        if (mesh.Vertices.Length == 0)
+        {
+            Console.Error.WriteLine(
+                "Found mesh with zero vertices: "
+                    + node.GetNodeName()
+                    + ". (ignoring). "
+            );
+            return null;
+        }
+
         // Apply the nodes WorldSpace transform to the mesh data, as we don't have transforms for mesh data in reveal.
         mesh.Apply(meshTransform);
         var triangleMesh = new TriangleMesh(mesh, treeIndex, color, mesh.CalculateAxisAlignedBoundingBox());


### PR DESCRIPTION
This fix checks for zero-vertex meshes when loading FBX files.
When found - error is reported and the mesh is skipped.
This should solve crashes* when loading fbx models containing such meshes.

* crashes are because bounding box of a zero-vertex mesh is ill-defined.