### PR TITLE
Add electrical, safety and instrumentation as prioritized sectors

### DIFF
--- a/CadRevealComposer/Operations/SectorSplitting/PrioritySplittingUtils.cs
+++ b/CadRevealComposer/Operations/SectorSplitting/PrioritySplittingUtils.cs
@@ -8,7 +8,7 @@ using Utils;
 
 public static class PrioritySplittingUtils
 {
-    private static readonly string[] PrioritizedDisciplines = ["PIPE"];
+    private static readonly string[] PrioritizedDisciplines = ["PIPE", "ELEC", "SAFE"];
 
     public static void SetPriorityForPrioritySplittingWithMutation(IReadOnlyList<CadRevealNode> nodes)
     {

--- a/CadRevealComposer/Operations/SectorSplitting/PrioritySplittingUtils.cs
+++ b/CadRevealComposer/Operations/SectorSplitting/PrioritySplittingUtils.cs
@@ -8,7 +8,7 @@ using Utils;
 
 public static class PrioritySplittingUtils
 {
-    private static readonly string[] PrioritizedDisciplines = ["PIPE", "ELEC", "SAFE"];
+    private static readonly string[] PrioritizedDisciplines = ["PIPE", "ELEC", "SAFE", "INST"];
 
     public static void SetPriorityForPrioritySplittingWithMutation(IReadOnlyList<CadRevealNode> nodes)
     {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Helper comments to guide you in filling the pull request.
     Feel free to delete the comments when you are filling out the template, or leave them as they will not be visible.
     If this is your first contribution: Consider reading CONTRIBUTING.md to understand the expectations of a pull-request. 📃
-->
### What have I made? 👩‍💻

Add electrical, safety and instrumentation equipment as prioritized sectors.

<!-- REMINDER: The rvmsharp repo is Public! The Pull-Request MUST NOT contain any Equinor Internal information. -->

<!-- Short description of your feature / fix.
Example: Adds a faster way to parse RVM files, using a memory layout improvement for 10x better read performance. This will make parsing faster, and enable runtime parsing in client code.
-->

<!-- Link to the issue you are working on. The format is #GitHubIssueId OR AB#DevOpsBoardsId -->

### How can you best review this? 🧐

Run some builds and check that build time doesn't increase and that there are not too many prioritized sectors.

<!-- A short description of how this should be reviewed, to help the reviewer better understand the code.
Example: This feature can be verified working as expected by observing the runtime lowered from 100 to 10 seconds on the Huldra Dataset.
         I also need a code review. I have self-commented in the review with some areas I would like to discuss if I could do this differently.
-->

### Did I remember everything checklist?
<!-- If any task is not applicable, just check it or strikethrough like this ~~This text will be strikethroughed~~  -->
<!-- If anything wont be checked, consider writing why in a sub-point
How to bulletpoints:
- [ ] I wrote some awesome code! 😎
  - There is no code :(
-->

- [x] I made some awesome changes! 😎
- [x] I left the code in a better state than when I started working on it ✨
- [x] ~~I wrote unit and/or integration tests 👾~~
- [x] I have considered any security implications, and requested review of them explicitly 🔐
- [x] I verified that it checks the acceptance criteria. 📜
- [x] I have tested this change in the Echo DEV environment, or requested someone to test it for me 🚀
- [ ] I updated the documentation/readme 📚
- [x] I made the PR title descriptive and human-readable 👨‍👩‍👦‍👦
- [ ] Existing unreported issues I found but could not fix was added as a new Issues 🚧

<!-- Metadata:
      The most updated source of this template is found in https://github.com/equinor/Echo/blob/master/docs/github.md#pull-request-templates
-->
