### PR TITLE
Do not dispose fbx importer as the dispose operation takes too long.

### DIFF
--- a/CadRevealFbxProvider/BatchUtils/FbxWorkload.cs
+++ b/CadRevealFbxProvider/BatchUtils/FbxWorkload.cs
@@ -77,7 +77,8 @@ public static class FbxWorkload
     {
         var progress = 0;
 
-        using var fbxImporter = new FbxImporter();
+        // FBX Importer is intentionally not disposed as the dispose operation takes too long. If this becomes a problem with memory leaks we need to investigate why the dispose is so slow.
+        var fbxImporter = new FbxImporter();
         if (!fbxImporter.HasValidSdk())
         {
             Console.WriteLine("Did not find valid SDK, cannot import FBX file.");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Helper comments to guide you in filling the pull request.
     Feel free to delete the comments when you are filling out the template, or leave them as they will not be visible.
     If this is your first contribution: Consider reading CONTRIBUTING.md to understand the expectations of a pull-request. 📃
-->
### What have I made? 👩‍💻

Reverting the change where the fbxsdk was disposed after use. This still takes to long, so we are intentionally not disposing it.

