### PR TITLE
Avoid potential bug where Ids are repeated

### DIFF
--- a/CadRevealComposer/IdProviders/SequentialIdGenerator.cs
+++ b/CadRevealComposer/IdProviders/SequentialIdGenerator.cs
@@ -8,17 +8,31 @@ public class SequentialIdGenerator(uint firstIdReturned = 0)
 
     private uint _internalIdCounter = firstIdReturned;
 
+    private object IdLock { get; } = new object();
+
     public uint GetNextId()
     {
-        var idToReturn = _internalIdCounter;
-        _internalIdCounter++;
-        if (idToReturn > MaxSafeIdForReveal)
-            throw new Exception("Id overflow. Ids are not safe for reveal anymore. " + "Max is " + MaxSafeIdForReveal);
-        return idToReturn;
+        lock (IdLock)
+        {
+            var idToReturn = _internalIdCounter;
+            _internalIdCounter++;
+            if (idToReturn > MaxSafeIdForReveal)
+                throw new Exception($"Id overflow. Ids are not safe for reveal anymore. Max is {MaxSafeIdForReveal}");
+            return idToReturn;
+        }
     }
 
     /// <summary>
     /// Look at the next id that will be generated
     /// </summary>
-    public uint PeekNextId => _internalIdCounter;
+    public uint PeekNextId
+    {
+        get
+        {
+            lock (IdLock)
+            {
+                return _internalIdCounter;
+            }
+        }
+    }
 }

--- a/CadRevealRvmProvider/Tessellation/RvmTessellator.cs
+++ b/CadRevealRvmProvider/Tessellation/RvmTessellator.cs
@@ -83,7 +83,6 @@ public class RvmTessellator
 
         var meshes = facetGroupInstanced
             .Concat(pyramidsInstanced)
-            .AsParallel()
             .Select(g =>
             {
                 var allTransforms = g.Select(x => x.Transform).ToArray();
@@ -102,6 +101,12 @@ public class RvmTessellator
             })
             .Where(g => g.Mesh.TriangleCount > 0) // ignore empty meshes
             .ToArray();
+
+        Trace.Assert(
+            meshes.DistinctBy(x => x.InstanceId).Count() == meshes.Length,
+            "InstanceId must be unique for each group of instances. This is a bug in the instancing code."
+        );
+
         var totalCount = meshes.Sum(m => m.InstanceGroup.Count());
         instanceTessellationLogObject.LogFailedTessellations();
 


### PR DESCRIPTION
### What have I made? 👩‍💻

This MAY have been a latent bug as the GetNextId was no longer thread safe. This re-adds thread safety.

Two templates may have shared Ids, and this would cause a matrix from another mesh to be used on a unrelated template mesh. May have caused the melkøya issue.

<!-- Link to the issue you are working on. The format is #GitHubIssueId OR AB#DevOpsBoardsId -->
Related to AB#

### How can you best review this? 🧐

Check CI build. And we will try to test on melkøya

### Screenshot or Profiling data 🤳 

<!-- Remove the "Screenshot or Profiling data" section if unused -->

<!-- Screenshots and gifs can be useful to understand how a feature should look or work.
Tip: Use `Windows-Shift-S` to take a quick screenshot, and press `Ctrl-V` to auto embed the image.
REMINDER: The rvmsharp repo is Public! Consider if screenshots would contain internal information.
          Screenshots of 3D models should either be of the Huldra dataset or be unidentifiable to where and what is imaged.
-->

### Did I remember everything checklist?
<!-- If any task is not applicable, just check it or strikethrough like this ~~This text will be strikethroughed~~  -->
<!-- If anything wont be checked, consider writing why in a sub-point
How to bulletpoints:
- [ ] I wrote some awesome code! 😎
  - There is no code :(
-->

- [x] I made some awesome changes! 😎
- [ ] I left the code in a better state than when I started working on it ✨
- [ ] I wrote unit and/or integration tests 👾
- [ ] I have considered any security implications, and requested review of them explicitly 🔐
- [ ] I verified that it checks the acceptance criteria. 📜
- [ ] I have tested this change in the Echo DEV environment, or requested someone to test it for me 🚀
- [ ] I updated the documentation/readme 📚
- [ ] I made the PR title descriptive and human-readable 👨‍👩‍👦‍👦
- [ ] Existing unreported issues I found but could not fix was added as a new Issues 🚧

<!-- Metadata:
      The most updated source of this template is found in https://github.com/equinor/Echo/blob/master/docs/github.md#pull-request-templates
-->
