### PR TITLE
Fix squashed nodes's bounding box

### DIFF
--- a/CadRevealRvmProvider/RvmStoreToCadRevealNodesConverter.cs
+++ b/CadRevealRvmProvider/RvmStoreToCadRevealNodesConverter.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using CadRevealComposer;
 using CadRevealComposer.IdProviders;
 using CadRevealComposer.Operations;
-using CadRevealComposer.Operations.SectorSplitting;
 using CadRevealComposer.Utils;
 using RvmSharp.Containers;
 using RvmSharp.Primitives;
@@ -175,9 +174,15 @@ internal static class RvmStoreToCadRevealNodesConverter
             .Select(x => x.CalculateAxisAlignedBoundingBox()?.ToCadRevealBoundingBox())
             .WhereNotNull()
             .ToArray();
+
+        var thisNodesGeometryBoundingBoxes = newNode.Geometries.Select(g => g.AxisAlignedBoundingBox).WhereNotNull();
+
         var childrenBounds = newNode.Children.Select(x => x.BoundingBoxAxisAligned).WhereNotNull();
 
-        var primitiveAndChildrenBoundingBoxes = primitiveBoundingBoxes.Concat(childrenBounds).ToArray();
+        var primitiveAndChildrenBoundingBoxes = primitiveBoundingBoxes
+            .Concat(childrenBounds)
+            .Concat(thisNodesGeometryBoundingBoxes)
+            .ToArray();
         newNode.BoundingBoxAxisAligned = primitiveAndChildrenBoundingBoxes.Any()
             ? primitiveAndChildrenBoundingBoxes.Aggregate((a, b) => a.Encapsulate(b))
             : null;


### PR DESCRIPTION
### What have I made? 👩‍💻

When squashing multiple levels of the hierarchy the recursive bounding box calculation was "off". This ensures that all geometry on the current part is included in the bounding box calculation.

<!-- Link to the issue you are working on. The format is #GitHubIssueId OR AB#DevOpsBoardsId -->
Related to AB#

### How can you best review this? 🧐

Check the code. I have tested the implementation and it works as expected.

### Did I remember everything checklist?
<!-- If any task is not applicable, just check it or strikethrough like this ~~This text will be strikethroughed~~  -->
<!-- If anything wont be checked, consider writing why in a sub-point
How to bulletpoints:
- [ ] I wrote some awesome code! 😎
  - There is no code :(
-->

- [x] I made some awesome changes! 😎
- [x] I left the code in a better state than when I started working on it ✨
- [ ] I wrote unit and/or integration tests 👾
- [x] I have considered any security implications, and requested review of them explicitly 🔐
- [x] I verified that it checks the acceptance criteria. 📜
- [x] I have tested this change in the Echo DEV environment, or requested someone to test it for me 🚀
- [x] I updated the documentation/readme 📚
- [x] I made the PR title descriptive and human-readable 👨‍👩‍👦‍👦
- [x] Existing unreported issues I found but could not fix was added as a new Issues 🚧

<!-- Metadata:
      The most updated source of this template is found in https://github.com/equinor/Echo/blob/master/docs/github.md#pull-request-templates
-->
