### PR TITLE
Improved checking if the filename follows the guidlines

### DIFF
--- a/CadRevealFbxProvider.Tests/Attributes/ScaffoldingMetadataTests.cs
+++ b/CadRevealFbxProvider.Tests/Attributes/ScaffoldingMetadataTests.cs
@@ -216,7 +216,7 @@ public class ScaffoldingMetadataTests
     }
 
     [Test]
-    public void ThrowIfWorkOrderFromFilenameInvalid_WhenWorkOrderMatches_ThenDoesNotThrow()
+    public void ThrowIfWorkOrderFromFilenameInvalid_WhenWorkOrderMatches_DoesNotThrow()
     {
         // Arrange
         var metadata = new ScaffoldingMetadata();
@@ -228,7 +228,7 @@ public class ScaffoldingMetadataTests
         var fileName = "BCA-12345678";
 
         // Act & Assert
-        Assert.DoesNotThrow(() => metadata.ThrowIfWorkOrderFromFilenameInvalid(fileName));
+        Assert.DoesNotThrow(() => metadata.ThrowIfFilenameInvalid(fileName));
     }
 
     [Test]
@@ -243,18 +243,62 @@ public class ScaffoldingMetadataTests
 
         // tested function expects filename without extension
         var fileName1 = "BCA-1234567"; // mismatch between filename and metadata
-        var fileName2 = "BCA_12345678"; // underscore in filename
-        var fileName3 = "BCA_"; // missing work order in filename
 
         // Act & Assert
         HelperFunctions.AssertThrowsCustomScaffoldingException<ScaffoldingFilenameException>(() =>
-            metadata.ThrowIfWorkOrderFromFilenameInvalid(fileName1)
+            metadata.ThrowIfFilenameInvalid(fileName1)
+        );
+    }
+
+    [Test]
+    public void ThrowIfWorkOrderFromFilenameInvalid_WhenFilenameCorrect_DoesNotThrow()
+    {
+        // Arrange
+        var metadata = new ScaffoldingMetadata();
+        metadata.WorkOrder = "12345678";
+        metadata.BuildOperationNumber = "1010";
+        metadata.DismantleOperationNumber = "1011";
+        metadata.TempScaffoldingFlag = false;
+
+        // tested function expects filename without extension
+        var fileName1 = "BCA-12345678"; // OK, has no suffix
+        var fileName2 = "BCA-12345678-A12"; // OK, has 1 suffix
+        var fileName3 = "BCA-12345678-A12-Part1"; // OK, has 2 suffixes
+
+        // Act & Assert
+        Assert.DoesNotThrow(() => metadata.ThrowIfFilenameInvalid(fileName1));
+        Assert.DoesNotThrow(() => metadata.ThrowIfFilenameInvalid(fileName2));
+        Assert.DoesNotThrow(() => metadata.ThrowIfFilenameInvalid(fileName3));
+    }
+
+    [Test]
+    public void ThrowIfWorkOrderFromFilenameInvalid_WhenFilenameNotMatchesTemplate_Throws()
+    {
+        // Arrange
+        var metadata = new ScaffoldingMetadata();
+        metadata.WorkOrder = "12345678";
+        metadata.BuildOperationNumber = "1010";
+        metadata.DismantleOperationNumber = "1011";
+        metadata.TempScaffoldingFlag = false;
+
+        // tested function expects filename without extension
+
+        var fileName1 = "BCA-12345678A12"; // NOT OK, work order should be digits only
+        var fileName2 = "BCA_12345678"; // underscore in filename
+        var fileName3 = "BCA_"; // missing work order in filename
+        var fileName4 = "BCA-12345678-A12-Del1.0"; // NOT OK, has dot in the suffix
+
+        HelperFunctions.AssertThrowsCustomScaffoldingException<ScaffoldingFilenameException>(() =>
+            metadata.ThrowIfFilenameInvalid(fileName1)
         );
         HelperFunctions.AssertThrowsCustomScaffoldingException<ScaffoldingFilenameException>(() =>
-            metadata.ThrowIfWorkOrderFromFilenameInvalid(fileName2)
+            metadata.ThrowIfFilenameInvalid(fileName2)
         );
         HelperFunctions.AssertThrowsCustomScaffoldingException<ScaffoldingFilenameException>(() =>
-            metadata.ThrowIfWorkOrderFromFilenameInvalid(fileName3)
+            metadata.ThrowIfFilenameInvalid(fileName3)
+        );
+        HelperFunctions.AssertThrowsCustomScaffoldingException<ScaffoldingFilenameException>(() =>
+            metadata.ThrowIfFilenameInvalid(fileName4)
         );
     }
 
@@ -274,10 +318,10 @@ public class ScaffoldingMetadataTests
 
         // Act & Assert
         HelperFunctions.AssertThrowsCustomScaffoldingException<Exception>(() =>
-            metadata.ThrowIfWorkOrderFromFilenameInvalid(fileName1)
+            metadata.ThrowIfFilenameInvalid(fileName1)
         );
         HelperFunctions.AssertThrowsCustomScaffoldingException<Exception>(() =>
-            metadata.ThrowIfWorkOrderFromFilenameInvalid(fileName2)
+            metadata.ThrowIfFilenameInvalid(fileName2)
         );
     }
 
@@ -312,7 +356,7 @@ public class ScaffoldingMetadataTests
 
         // Act & Assert
         HelperFunctions.AssertThrowsCustomScaffoldingException<ScaffoldingFilenameException>(() =>
-            metadata.ThrowIfWorkOrderFromFilenameInvalid(fileName1)
+            metadata.ThrowIfFilenameInvalid(fileName1)
         );
     }
 }

--- a/CadRevealFbxProvider.Tests/Attributes/ScaffoldingMetadataTests.cs
+++ b/CadRevealFbxProvider.Tests/Attributes/ScaffoldingMetadataTests.cs
@@ -216,7 +216,7 @@ public class ScaffoldingMetadataTests
     }
 
     [Test]
-    public void ThrowIfWorkOrderFromFilenameInvalid_WhenWorkOrderMatches_DoesNotThrow()
+    public void ThrowIfFilenameInvalid_WhenWorkOrderMatches_DoesNotThrow()
     {
         // Arrange
         var metadata = new ScaffoldingMetadata();
@@ -232,7 +232,7 @@ public class ScaffoldingMetadataTests
     }
 
     [Test]
-    public void ThrowIfWorkOrderFromFilenameInvalid_WhenWorkOrderMismatches_Throws()
+    public void ThrowIfFilenameInvalid_WhenWorkOrderMismatches_Throws()
     {
         // Arrange
         var metadata = new ScaffoldingMetadata();
@@ -251,7 +251,7 @@ public class ScaffoldingMetadataTests
     }
 
     [Test]
-    public void ThrowIfWorkOrderFromFilenameInvalid_WhenFilenameCorrect_DoesNotThrow()
+    public void ThrowIfFilenameInvalid_WhenFilenameCorrect_DoesNotThrow()
     {
         // Arrange
         var metadata = new ScaffoldingMetadata();
@@ -272,7 +272,7 @@ public class ScaffoldingMetadataTests
     }
 
     [Test]
-    public void ThrowIfWorkOrderFromFilenameInvalid_WhenFilenameNotMatchesTemplate_Throws()
+    public void ThrowIfFilenameInvalid_WhenFilenameNotMatchesTemplate_Throws()
     {
         // Arrange
         var metadata = new ScaffoldingMetadata();
@@ -283,7 +283,7 @@ public class ScaffoldingMetadataTests
 
         // tested function expects filename without extension
 
-        var fileName1 = "BCA-12345678A12"; // NOT OK, work order should be digits only
+        var fileName1 = "BCA-12345678A12"; // NOT OK, work order should be digits only, we have seen architects mistakently enter WO like this sometimes
         var fileName2 = "BCA_12345678"; // underscore in filename
         var fileName3 = "BCA_"; // missing work order in filename
         var fileName4 = "BCA-12345678-A12-Del1.0"; // NOT OK, has dot in the suffix
@@ -303,7 +303,7 @@ public class ScaffoldingMetadataTests
     }
 
     [Test]
-    public void ThrowIfWorkOrderFromFilenameInvalid_WhenCallingOnTempScaff_Throws()
+    public void ThrowIfFilenameInvalid_WhenCallingOnTempScaff_Throws()
     {
         // Arrange
         var metadata = new ScaffoldingMetadata();

--- a/CadRevealFbxProvider.Tests/Attributes/ScaffoldingMetadataTests.cs
+++ b/CadRevealFbxProvider.Tests/Attributes/ScaffoldingMetadataTests.cs
@@ -326,23 +326,7 @@ public class ScaffoldingMetadataTests
     }
 
     [Test]
-    [TestCase("/abc-123456789-woScaffCorrect", "woScaffCorrect")]
-    [TestCase("/abc-123456789", "")]
-    [TestCase("/abc-123456789-", "")]
-    [TestCase("/abc-123456789-suffix.with.dots", "suffix.with.dots")]
-    [TestCase("/abc-123456789--suffix--with-dashes", "-suffix--with-dashes")]
-    public void GetSuffixFromFilename_ExtractsCorrectSuffix(string fileNameWoExtension, string expectedResult)
-    {
-        // Arrange
-        var metadata = new ScaffoldingMetadata();
-
-        metadata.GetSuffixFromFilename(fileNameWoExtension);
-
-        Assert.That(metadata.NameSuffix, Is.EqualTo(expectedResult));
-    }
-
-    [Test]
-    public void ThrowIfWorkOrderFromFilenameInvalid_WhenWorkOrderNotPreceededByCode_Throws()
+    public void ThrowIfFilenameInvalid_WhenWorkOrderNotPreceededByCode_Throws()
     {
         // Arrange
         var metadata = new ScaffoldingMetadata();
@@ -358,5 +342,21 @@ public class ScaffoldingMetadataTests
         HelperFunctions.AssertThrowsCustomScaffoldingException<ScaffoldingFilenameException>(() =>
             metadata.ThrowIfFilenameInvalid(fileName1)
         );
+    }
+
+    [Test]
+    [TestCase("/abc-123456789-woScaffCorrect", "woScaffCorrect")]
+    [TestCase("/abc-123456789", "")]
+    [TestCase("/abc-123456789-", "")]
+    [TestCase("/abc-123456789-suffix.with.dots", "suffix.with.dots")]
+    [TestCase("/abc-123456789--suffix--with-dashes", "-suffix--with-dashes")]
+    public void GetSuffixFromFilename_ExtractsCorrectSuffix(string fileNameWoExtension, string expectedResult)
+    {
+        // Arrange
+        var metadata = new ScaffoldingMetadata();
+
+        metadata.GetSuffixFromFilename(fileNameWoExtension);
+
+        Assert.That(metadata.NameSuffix, Is.EqualTo(expectedResult));
     }
 }

--- a/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
+++ b/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
@@ -197,7 +197,11 @@ public class ScaffoldingMetadata
         }
     }
 
-    public void ThrowIfWorkOrderFromFilenameInvalid(string filename)
+    // Filename checking for non-TEMP scaffolding files
+    // throws if filename is not compliant with the guidlines:
+    // Plant code (3 alphabetical letters) - work order number (digits only) - suffixes (optional, but a-zA-Z only, can be multiple, separated by "-")
+    // Work order number must match the work order number in the metadata
+    public void ThrowIfFilenameInvalid(string filename)
     {
         // this function is only called for work order scaffolding files
         // so calling this for temp scaffs must be by mistake, -> throw an exception
@@ -211,7 +215,7 @@ public class ScaffoldingMetadata
             );
         }
 
-        var match = Regex.Match(filename, @"^[A-Z]{3,}-(\d+)(?:-|$)");
+        var match = Regex.Match(filename, @"^[A-Z]{3,}-(\d+)(?:(-[a-zA-Z\d]+)+$|$)");
         if (match.Success)
         {
             string workOrderFromFilename = match.Groups[1].Value;

--- a/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
+++ b/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
@@ -198,8 +198,8 @@ public class ScaffoldingMetadata
     }
 
     // Filename checking for non-TEMP scaffolding files
-    // throws if filename is not compliant with the guidlines:
-    // Plant code (3 alphabetical letters) - work order number (digits only) - suffixes (optional, but a-zA-Z only, can be multiple, separated by "-")
+    // throws if filename is not compliant with the guidelines:
+    // Plant code (usually 3 alphabetical letters) - work order number (digits only) - suffixes (optional, consist of alphanumeric characters, can be multiple, separated by "-")
     // Work order number must match the work order number in the metadata
     public void ThrowIfFilenameInvalid(string filename)
     {
@@ -240,7 +240,7 @@ public class ScaffoldingMetadata
             throw new UserFriendlyLogException(
                 "",
                 new ScaffoldingFilenameException(
-                    $"Scaffolding CSV file {filename} does not contain a correctly-formatted work order number in the filename. Please check the naming guide."
+                    $"Scaffolding file's {filename} filename is not following the naming guide. Please check the naming guide."
                 )
             );
         }

--- a/CadRevealFbxProvider/BatchUtils/FbxWorkload.cs
+++ b/CadRevealFbxProvider/BatchUtils/FbxWorkload.cs
@@ -121,9 +121,10 @@ public static class FbxWorkload
                 if (!isTemp)
                 {
                     // check if the WO from filename actually matches the metadata
+                    // check if the filename is complying with the guidlines
                     // for non-temp scaffs only
                     // crashes if there is a mismatch
-                    scaffoldingMetadata.ThrowIfWorkOrderFromFilenameInvalid(fileNameonly);
+                    scaffoldingMetadata.ThrowIfFilenameInvalid(fileNameonly);
                 }
                 scaffoldingMetadata.GetSuffixFromFilename(fileNameonly);
                 // We crash if we dont have expected values


### PR DESCRIPTION
We have previously not been checking the filename beyond the WO number. Possible errors (like filename suffixes containing characters that not allowed) were not caught before a later power shell script, and thus not handles gracefully.

Acceptance criteria: If the pipeline gets to process a scaffolding with a filename that does not comply (including those containing illegal characters in the suffix), it should throw an error, and not succeed.

<!-- markdownlint-disable MD041 -->
<!-- Helper comments to guide you in filling the pull request.
     Feel free to delete the comments when you are filling out the template, or leave them as they will not be visible.
     If this is your first contribution: Consider reading CONTRIBUTING.md to understand the expectations of a pull-request. 📃
-->
### What have I made? 👩‍💻

<!-- REMINDER: The rvmsharp repo is Public! The Pull-Request MUST NOT contain any Equinor Internal information. -->

I extended the regex expression for checking, changed the method name and subscriptions accordingly. Added some tests as well.

<!-- Short description of your feature / fix.
Example: Adds a faster way to parse RVM files, using a memory layout improvement for 10x better read performance. This will make parsing faster, and enable runtime parsing in client code.
-->

<!-- Link to the issue you are working on. The format is #GitHubIssueId OR AB#DevOpsBoardsId -->
Related to [AB#414532](https://dev.azure.com/EquinorASA/13429306-9600-4820-ac5c-3e7d26fa3cb9/_workitems/edit/414532)

### How can you best review this? 🧐
Check the source code and maybe did some more regex match testing using [regexr](https://regexr.com/).

<!-- A short description of how this should be reviewed, to help the reviewer better understand the code.
Example: This feature can be verified working as expected by observing the runtime lowered from 100 to 10 seconds on the Huldra Dataset.
         I also need a code review. I have self-commented in the review with some areas I would like to discuss if I could do this differently.
-->


<!-- Screenshots and gifs can be useful to understand how a feature should look or work.
Tip: Use `Windows-Shift-S` to take a quick screenshot, and press `Ctrl-V` to auto embed the image.
REMINDER: The rvmsharp repo is Public! Consider if screenshots would contain internal information.
          Screenshots of 3D models should either be of the Huldra dataset or be unidentifiable to where and what is imaged.
-->

### Did I remember everything checklist?
<!-- If any task is not applicable, just check it or strikethrough like this ~~This text will be strikethroughed~~  -->
<!-- If anything wont be checked, consider writing why in a sub-point
How to bulletpoints:
- [ ] I wrote some awesome code! 😎
  - There is no code :(
-->

- [x] I made some awesome changes! 😎
- [x] I left the code in a better state than when I started working on it ✨
- [x] I wrote unit and/or integration tests 👾
- [ ] I have considered any security implications, and requested review of them explicitly 🔐
- [x] I verified that it checks the acceptance criteria. 📜
- [ ] I have tested this change in the Echo DEV environment, or requested someone to test it for me 🚀
- [ ] I updated the documentation/readme 📚
- [x] I made the PR title descriptive and human-readable 👨‍👩‍👦‍👦
- [ ] Existing unreported issues I found but could not fix was added as a new Issues 🚧

<!-- Metadata:
      The most updated source of this template is found in https://github.com/equinor/Echo/blob/master/docs/github.md#pull-request-templates
-->
