### PR TITLE
When filename check fails add error message to the custom exception 

### DIFF
--- a/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
+++ b/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
@@ -238,7 +238,7 @@ public class ScaffoldingMetadata
         else
         {
             throw new UserFriendlyLogException(
-                $"Scaffolding file's {filename} filename is not following the naming guide. Please check the naming guide.",
+                $"Scaffolding file's {filename} filename is not following the naming guide. Filename should consist of max 55 characters. Use only english alphabetic letters a-z or A-Z, digits 0-9 and dashes \"-\". For example, spaces, dots and special characters are not allowed. Check also the naming guide.",
                 new ScaffoldingFilenameException(
                     $"Scaffolding file's {filename} filename is not following the naming guide. Please check the naming guide."
                 )

--- a/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
+++ b/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
@@ -228,20 +228,14 @@ public class ScaffoldingMetadata
             if (string.IsNullOrEmpty(workOrderFromFilename) || workOrderFromFilename != WorkOrder)
             {
                 throw new UserFriendlyLogException(
-                    $"Scaffolding work order {WorkOrder} extracted from the CSV file does not match the work order from filename {workOrderFromFilename}. Check if you stored the files under the correct name.",
-                    new ScaffoldingFilenameException(
-                        $"Scaffolding metadata work order {WorkOrder} does not match the work order from filename {workOrderFromFilename}"
-                    )
+                    $"Scaffolding work order {WorkOrder} extracted from the CSV file does not match the work order from filename {workOrderFromFilename}. Check if you stored the files under the correct name."
                 );
             }
         }
         else
         {
             throw new UserFriendlyLogException(
-                $"Scaffolding file's {filename} filename is not following the naming guide. Use only english alphabetic letters a-z or A-Z, digits 0-9 and dashes \"-\". For example, spaces, dots and special characters are not allowed. Check also the naming guide.",
-                new ScaffoldingFilenameException(
-                    $"Scaffolding file's {filename} filename is not following the naming guide. Please check the naming guide."
-                )
+                $"Scaffolding file's {filename} filename is not following the naming guide. Use only english alphabetic letters a-z or A-Z, digits 0-9 and dashes \"-\". For example, spaces, dots and special characters, such as æøå, are not allowed. Check also the naming guide."
             );
         }
     }

--- a/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
+++ b/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
@@ -238,7 +238,7 @@ public class ScaffoldingMetadata
         else
         {
             throw new UserFriendlyLogException(
-                $"Scaffolding file's {filename} filename is not following the naming guide. Filename should consist of max 55 characters. Use only english alphabetic letters a-z or A-Z, digits 0-9 and dashes \"-\". For example, spaces, dots and special characters are not allowed. Check also the naming guide.",
+                $"Scaffolding file's {filename} filename is not following the naming guide. Use only english alphabetic letters a-z or A-Z, digits 0-9 and dashes \"-\". For example, spaces, dots and special characters are not allowed. Check also the naming guide.",
                 new ScaffoldingFilenameException(
                     $"Scaffolding file's {filename} filename is not following the naming guide. Please check the naming guide."
                 )

--- a/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
+++ b/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
@@ -238,7 +238,7 @@ public class ScaffoldingMetadata
         else
         {
             throw new UserFriendlyLogException(
-                "",
+                $"Scaffolding file's {filename} filename is not following the naming guide. Please check the naming guide.",
                 new ScaffoldingFilenameException(
                     $"Scaffolding file's {filename} filename is not following the naming guide. Please check the naming guide."
                 )

--- a/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
+++ b/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
@@ -208,14 +208,15 @@ public class ScaffoldingMetadata
         if (TempScaffoldingFlag)
         {
             throw new UserFriendlyLogException(
-                "Work order scaffolding processing called for temporary scaffolds. This must be a bug. Please, notify the Echo developing team.",
+                "Work order scaffolding processing routine called for temporary scaffolds. This must be a bug. Please, notify the Echo developing team.",
                 new Exception(
-                    "Scaffolding metadata implies we expect a temporary scaffolding file, but this method is only for work order scaffolding files."
+                    "Scaffolding metadata implies we expect a temporary scaffolding file, but this method is only for work order scaffolding files. The flow should never get to this point."
                 )
             );
         }
 
-        var match = Regex.Match(filename, @"^[A-Z]{3,}-(\d+)(?:(-[a-zA-Z\d]+)+$|$)");
+        var regexPattern = @"^[A-Z]{3,}-(\d+)(?:(-[a-zA-Z\d]+)+$|$)";
+        var match = Regex.Match(filename, regexPattern);
         if (match.Success)
         {
             string workOrderFromFilename = match.Groups[1].Value;
@@ -228,14 +229,20 @@ public class ScaffoldingMetadata
             if (string.IsNullOrEmpty(workOrderFromFilename) || workOrderFromFilename != WorkOrder)
             {
                 throw new UserFriendlyLogException(
-                    $"Scaffolding work order {WorkOrder} extracted from the CSV file does not match the work order from filename {workOrderFromFilename}. Check if you stored the files under the correct name."
+                    $"Scaffolding work order {WorkOrder} extracted from the CSV file does not match the work order from filename {workOrderFromFilename}. Check if you stored the files under the correct name.",
+                    new ScaffoldingFilenameException(
+                        $"Scaffolding metadata work order {WorkOrder} does not match the work order from filename {workOrderFromFilename} or the work order from filename is null."
+                    )
                 );
             }
         }
         else
         {
             throw new UserFriendlyLogException(
-                $"Scaffolding file's {filename} filename is not following the naming guide. Use only english alphabetic letters a-z or A-Z, digits 0-9 and dashes \"-\". For example, spaces, dots and special characters, such as æøå, are not allowed. Check also the naming guide."
+                $"Scaffolding file's {filename} filename is not following the naming guide. Use only english alphabetic letters a-z or A-Z, digits 0-9 and dashes \"-\". For example, spaces, dots and special characters, such as æøå, are not allowed. Check also the naming guide.",
+                new ScaffoldingFilenameException(
+                    $"Scaffolding file's {filename} filename is not matching the regex {regexPattern}, because it is not following the naming guide."
+                )
             );
         }
     }

--- a/CadRevealFbxProvider/BatchUtils/FbxWorkload.cs
+++ b/CadRevealFbxProvider/BatchUtils/FbxWorkload.cs
@@ -119,7 +119,8 @@ public static class FbxWorkload
                 if (fileNameonly.Length > 55)
                 {
                     throw new UserFriendlyLogException(
-                        $"Scaffolding file's {fileNameonly} filename has {fileNameonly.Length} characters and is exceeding the maximum allowed length of 55 characters. Check the naming guide."
+                        $"Scaffolding file's {fileNameonly} filename has {fileNameonly.Length} characters and is exceeding the maximum allowed length of 55 characters. Check the naming guide.",
+                        new ScaffoldingFilenameException($"Filename too long: {fileNameonly}")
                     );
                 }
 

--- a/CadRevealFbxProvider/BatchUtils/FbxWorkload.cs
+++ b/CadRevealFbxProvider/BatchUtils/FbxWorkload.cs
@@ -114,6 +114,18 @@ public static class FbxWorkload
             {
                 var lines = File.ReadAllLines(infoTextFilename);
                 var fileNameonly = Path.GetFileNameWithoutExtension(infoTextFilename);
+
+                // check the length of the filename. Upload artifacts will fail with too long filenames
+                if (fileNameonly.Length > 55)
+                {
+                    throw new UserFriendlyLogException(
+                        $"Scaffolding file's {fileNameonly} filename is exceeding the maximum allowed length of 55 characters. Check the naming guide.",
+                        new ScaffoldingFilenameException(
+                            $"Scaffolding file's {fileNameonly} filename is exceeding the maximum allowed length of 55 characters. Please check the naming guide."
+                        )
+                    );
+                }
+
                 var isTemp = fileNameonly.Contains("TEMP", StringComparison.OrdinalIgnoreCase);
 
                 (attributes, var scaffoldingMetadata) = ScaffoldingAttributeParser.ParseAttributes(lines, isTemp);

--- a/CadRevealFbxProvider/BatchUtils/FbxWorkload.cs
+++ b/CadRevealFbxProvider/BatchUtils/FbxWorkload.cs
@@ -119,10 +119,7 @@ public static class FbxWorkload
                 if (fileNameonly.Length > 55)
                 {
                     throw new UserFriendlyLogException(
-                        $"Scaffolding file's {fileNameonly} filename is exceeding the maximum allowed length of 55 characters. Check the naming guide.",
-                        new ScaffoldingFilenameException(
-                            $"Scaffolding file's {fileNameonly} filename is exceeding the maximum allowed length of 55 characters. Please check the naming guide."
-                        )
+                        $"Scaffolding file's {fileNameonly} filename has {fileNameonly.Length()} characters and is exceeding the maximum allowed length of 55 characters. Check the naming guide."
                     );
                 }
 

--- a/CadRevealFbxProvider/BatchUtils/FbxWorkload.cs
+++ b/CadRevealFbxProvider/BatchUtils/FbxWorkload.cs
@@ -119,7 +119,7 @@ public static class FbxWorkload
                 if (fileNameonly.Length > 55)
                 {
                     throw new UserFriendlyLogException(
-                        $"Scaffolding file's {fileNameonly} filename has {fileNameonly.Length()} characters and is exceeding the maximum allowed length of 55 characters. Check the naming guide."
+                        $"Scaffolding file's {fileNameonly} filename has {fileNameonly.Length} characters and is exceeding the maximum allowed length of 55 characters. Check the naming guide."
                     );
                 }
 


### PR DESCRIPTION
The custom exception text was empty for some reason (bug).

<!-- markdownlint-disable MD041 -->
<!-- Helper comments to guide you in filling the pull request.
     Feel free to delete the comments when you are filling out the template, or leave them as they will not be visible.
     If this is your first contribution: Consider reading CONTRIBUTING.md to understand the expectations of a pull-request. 📃
-->
### What have I made? 👩‍💻

<!-- REMINDER: The rvmsharp repo is Public! The Pull-Request MUST NOT contain any Equinor Internal information. -->

<!-- Short description of your feature / fix.
Example: Adds a faster way to parse RVM files, using a memory layout improvement for 10x better read performance. This will make parsing faster, and enable runtime parsing in client code.
-->

<!-- Link to the issue you are working on. The format is #GitHubIssueId OR AB#DevOpsBoardsId -->
Related to AB#

### How can you best review this? 🧐

<!-- A short description of how this should be reviewed, to help the reviewer better understand the code.
Example: This feature can be verified working as expected by observing the runtime lowered from 100 to 10 seconds on the Huldra Dataset.
         I also need a code review. I have self-commented in the review with some areas I would like to discuss if I could do this differently.
-->

### Screenshot or Profiling data 🤳 

<!-- Remove the "Screenshot or Profiling data" section if unused -->

<!-- Screenshots and gifs can be useful to understand how a feature should look or work.
Tip: Use `Windows-Shift-S` to take a quick screenshot, and press `Ctrl-V` to auto embed the image.
REMINDER: The rvmsharp repo is Public! Consider if screenshots would contain internal information.
          Screenshots of 3D models should either be of the Huldra dataset or be unidentifiable to where and what is imaged.
-->

### Did I remember everything checklist?
<!-- If any task is not applicable, just check it or strikethrough like this ~~This text will be strikethroughed~~  -->
<!-- If anything wont be checked, consider writing why in a sub-point
How to bulletpoints:
- [ ] I wrote some awesome code! 😎
  - There is no code :(
-->

- [x] I made some awesome changes! 😎
- [ ] I left the code in a better state than when I started working on it ✨
- [ ] I wrote unit and/or integration tests 👾
- [ ] I have considered any security implications, and requested review of them explicitly 🔐
- [ ] I verified that it checks the acceptance criteria. 📜
- [ ] I have tested this change in the Echo DEV environment, or requested someone to test it for me 🚀
- [ ] I updated the documentation/readme 📚
- [ ] I made the PR title descriptive and human-readable 👨‍👩‍👦‍👦
- [ ] Existing unreported issues I found but could not fix was added as a new Issues 🚧

<!-- Metadata:
      The most updated source of this template is found in https://github.com/equinor/Echo/blob/master/docs/github.md#pull-request-templates
-->
