### PR TITLE
Add stid document number to scaffolding metadata.

### DIFF
--- a/CadRevealFbxProvider.Tests/FbxProviderTests.cs
+++ b/CadRevealFbxProvider.Tests/FbxProviderTests.cs
@@ -350,6 +350,9 @@ public class FbxProviderTests
         );
 
         // assert
+        // metadata is setup correctly (processing has succeeded)
+        Assert.That(metadata!.CheckValue("Scaffolding_NameSuffix", "Temp model"), Is.True);
+        Assert.That(metadata!.CheckValue("Scaffolding_StidDocumentId", "SCAFF-001"), Is.True);
         Assert.That(metadata!.CheckValue("Scaffolding_IsTemporary", "true"), Is.True);
     }
 
@@ -371,7 +374,9 @@ public class FbxProviderTests
         );
 
         // assert
+        // metadata is setup correctly (processing has succeeded)
         Assert.That(metadata!.CheckValue("Scaffolding_IsTemporary", "false"), Is.True);
+        Assert.That(metadata!.CheckValue("Scaffolding_StidDocumentId", "SCAFF-002"), Is.True);
         Assert.That(metadata!.CheckValue("Scaffolding_NameSuffix", "Valid model"), Is.True);
     }
 

--- a/CadRevealFbxProvider.Tests/FbxProviderTests.cs
+++ b/CadRevealFbxProvider.Tests/FbxProviderTests.cs
@@ -330,7 +330,8 @@ public class FbxProviderTests
         );
 
         // assert
-        Assert.That(metadata!.CheckValue("Scaffolding_NameSuffix", "test"), Is.True);
+        // name suffix will not be tested.
+        // It is not extracted correctly from temp scaffoldings, but that is also irrelevant (old pipeline).
         Assert.That(metadata!.CheckValue("Scaffolding_StidDocumentId", string.Empty), Is.True);
         Assert.That(metadata!.CheckValue("Scaffolding_IsTemporary", "true"), Is.True);
     }

--- a/CadRevealFbxProvider.Tests/FbxProviderTests.cs
+++ b/CadRevealFbxProvider.Tests/FbxProviderTests.cs
@@ -263,6 +263,7 @@ public class FbxProviderTests
         );
 
         Assert.That(metadata!.CheckValue("Scaffolding_NameSuffix", suffix), Is.True);
+        Assert.That(metadata!.CheckValue("Scaffolding_StidDocumentId", string.Empty), Is.True);
     }
 
     [TestCase(InputDirectoryCorrect)]
@@ -329,6 +330,8 @@ public class FbxProviderTests
         );
 
         // assert
+        Assert.That(metadata!.CheckValue("Scaffolding_NameSuffix", "test"), Is.True);
+        Assert.That(metadata!.CheckValue("Scaffolding_StidDocumentId", string.Empty), Is.True);
         Assert.That(metadata!.CheckValue("Scaffolding_IsTemporary", "true"), Is.True);
     }
 

--- a/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
+++ b/CadRevealFbxProvider/Attributes/ScaffoldingMetadata.cs
@@ -17,6 +17,8 @@ public class ScaffoldingMetadata
 
     public string? NameSuffix { get; set; }
 
+    public string? StidDocumentId { get; set; }
+
     private const string WorkOrderFieldName = "Scaffolding_WorkOrder_WorkOrderNumber";
     private const string BuildOpFieldName = "Scaffolding_WorkOrder_BuildOperationNumber";
     private const string DismantleOpFieldName = "Scaffolding_WorkOrder_DismantleOperationNumber";
@@ -25,6 +27,7 @@ public class ScaffoldingMetadata
     private const string TotalWeightCalculatedFieldName = "Scaffolding_TotalWeightCalc";
     private const string TempFlagFieldName = "Scaffolding_IsTemporary";
     private const string SuffixFieldName = "Scaffolding_NameSuffix";
+    private const string StidDocumentIdFieldName = "Scaffolding_StidDocumentId";
 
     private static readonly string[] MandatoryModelAttributesFromPartsNonTempScaff =
     [
@@ -39,7 +42,10 @@ public class ScaffoldingMetadata
 
     public static readonly int NumberOfModelAttributes =
         Enum.GetNames(typeof(AttributeEnum)).Length
-        + 1 /*file suffix*/
+        - 1 /* project number is not used in metadata */
+        + 1 /* name suffix aka human readable title */
+        + 1 /* temp flag */
+        + 1 /* stid document number*/
     ;
     public static readonly int NumberOfMandatoryModelAttributesFromPartsNonTempScaff =
         MandatoryModelAttributesFromPartsNonTempScaff.Length;
@@ -333,5 +339,6 @@ public class ScaffoldingMetadata
         targetDict.Add(TotalWeightCalculatedFieldName, TotalWeightCalculated!);
         targetDict.Add(TempFlagFieldName, TempScaffoldingFlag ? "true" : "false");
         targetDict.Add(SuffixFieldName, NameSuffix ?? "");
+        targetDict.Add(StidDocumentIdFieldName, StidDocumentId ?? "");
     }
 }

--- a/CadRevealFbxProvider/Attributes/StidScaffoldingDocumentEchoDto.cs
+++ b/CadRevealFbxProvider/Attributes/StidScaffoldingDocumentEchoDto.cs
@@ -11,6 +11,11 @@
     public record StidScaffoldingDocumentEchoDto
     {
         /// <summary>
+        /// The document number (document ID)
+        /// </summary>
+        public required string DocNo { get; init; }
+
+        /// <summary>
         /// Title of the document, here used as suffix after the algorithmically created document name
         /// </summary>
         public required string DocTitle { get; init; }

--- a/CadRevealFbxProvider/BatchUtils/FbxWorkload.cs
+++ b/CadRevealFbxProvider/BatchUtils/FbxWorkload.cs
@@ -161,6 +161,7 @@ public static class FbxWorkload
                         scaffoldingMetadata.ThrowIfFilenameInvalid(fileNameonly);
                     }
                     scaffoldingMetadata.GetSuffixFromFilename(fileNameonly);
+                    scaffoldingMetadata.StidDocumentId = "";
                     // We crash if we dont have expected values
                     scaffoldingMetadata.TryWriteToGenericMetadataDict(metadata);
                 }
@@ -193,7 +194,7 @@ public static class FbxWorkload
                             );
                         }
                     }
-
+                    scaffoldingMetadata.StidDocumentId = stidMetadata.DocNo;
                     scaffoldingMetadata.NameSuffix = stidMetadata.DocTitle;
                     scaffoldingMetadata.TryWriteToGenericMetadataDict(metadata);
                 }


### PR DESCRIPTION
### What have I made? 👩‍💻

<!-- REMINDER: The rvmsharp repo is Public! The Pull-Request MUST NOT contain any Equinor Internal information. -->

<!-- Link to the issue you are working on. The format is #GitHubIssueId OR AB#DevOpsBoardsId -->
Related to [AB#451061](https://dev.azure.com/EquinorASA/13429306-9600-4820-ac5c-3e7d26fa3cb9/_workitems/edit/451061)

Adding the stid document number (together with the installation code, it forms a unique ID in STID), Echo 3D Web will be able to link the scaffolding with the STID document. Echo 3D Web has only the metadata json as information about the model.

### How can you best review this? 🧐

<!-- A short description of how this should be reviewed, to help the reviewer better understand the code.
Example: This feature can be verified working as expected by observing the runtime lowered from 100 to 10 seconds on the Huldra Dataset.
         I also need a code review. I have self-commented in the review with some areas I would like to discuss if I could do this differently.
-->

<!-- Remove the "Screenshot or Profiling data" section if unused -->

<!-- Screenshots and gifs can be useful to understand how a feature should look or work.
Tip: Use `Windows-Shift-S` to take a quick screenshot, and press `Ctrl-V` to auto embed the image.
REMINDER: The rvmsharp repo is Public! Consider if screenshots would contain internal information.
          Screenshots of 3D models should either be of the Huldra dataset or be unidentifiable to where and what is imaged.
-->

### Did I remember everything checklist?
<!-- If any task is not applicable, just check it or strikethrough like this ~~This text will be strikethroughed~~  -->
<!-- If anything wont be checked, consider writing why in a sub-point
How to bulletpoints:
- [ ] I wrote some awesome code! 😎
  - There is no code :(
-->

- [x] I made some awesome changes! 😎
- [x] I left the code in a better state than when I started working on it ✨
- [x] I wrote unit and/or integration tests 👾
- [ ] I have considered any security implications, and requested review of them explicitly 🔐
- [x] I verified that it checks the acceptance criteria. 📜
- [ ] I have tested this change in the Echo DEV environment, or requested someone to test it for me 🚀
- [ ] I updated the documentation/readme 📚
- [ ] I made the PR title descriptive and human-readable 👨‍👩‍👦‍👦
- [ ] Existing unreported issues I found but could not fix was added as a new Issues 🚧

<!-- Metadata:
      The most updated source of this template is found in https://github.com/equinor/Echo/blob/master/docs/github.md#pull-request-templates
-->
